### PR TITLE
More schema reader

### DIFF
--- a/core/schema/link.go
+++ b/core/schema/link.go
@@ -1,0 +1,129 @@
+package schema
+
+import (
+	"bytes"
+	"fmt"
+
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/multiformats/go-base32"
+	mh "github.com/multiformats/go-multihash"
+	"github.com/storacha-network/go-ucanto/core/ipld"
+	"github.com/storacha-network/go-ucanto/core/result/failure"
+)
+
+type linkReader struct {
+	lc *linkCfg
+}
+
+func (lr linkReader) Read(input any) (ipld.Link, failure.Failure) {
+	link, asLink := input.(ipld.Link)
+	if !asLink {
+		node, asNode := input.(ipld.Node)
+		if !asNode {
+			// If input is not an IPLD node, can it be converted to one?
+			if builder, ok := input.(ipld.Builder); ok {
+				n, err := builder.Build()
+				if err != nil {
+					return nil, NewSchemaError(err.Error())
+				}
+				node = n
+			} else {
+				return nil, NewSchemaError("unexpected input: not an IPLD node or link")
+			}
+		}
+		var err error
+		link, err = node.AsLink()
+		if err != nil {
+			return nil, NewSchemaError(err.Error())
+		}
+	}
+
+	cidLink, ok := link.(cidlink.Link)
+	if !ok {
+		return nil, NewSchemaError("Unsupported Link Type")
+	}
+	cid := cidLink.Cid
+	if lr.lc.codec != nil && cid.Prefix().Codec != *lr.lc.codec {
+		return nil, NewSchemaError(fmt.Sprintf("Expected link to be CID with %X codec", *lr.lc.codec))
+	}
+
+	if lr.lc.version != nil && cid.Prefix().Version != *lr.lc.version {
+		return nil, NewSchemaError(fmt.Sprintf(
+			"Expected link to be CID version %d instead of %d", *lr.lc.version, cid.Prefix().Version))
+	}
+
+	if lr.lc.multihash != nil {
+		multihash := lr.lc.multihash
+		if multihash.code != nil && cid.Prefix().MhType != *multihash.code {
+			return nil, NewSchemaError(fmt.Sprintf("Expected link to be CID with %X hashing algorithm", *&multihash.code))
+		}
+		if multihash.digest != nil {
+			decoded, err := mh.Decode(cid.Hash())
+			if err != nil {
+				return nil, NewSchemaError(err.Error())
+			}
+
+			if bytes.Compare(decoded.Digest, *multihash.digest) != 0 {
+				return nil, NewSchemaError(fmt.Sprintf("Expected link with %s hash digest instead of %s", base32.StdEncoding.EncodeToString(*multihash.digest), base32.StdEncoding.EncodeToString(decoded.Digest)))
+			}
+		}
+	}
+	return link, nil
+}
+
+type multihashConfig struct {
+	code   *uint64
+	digest *[]byte
+}
+
+type MultihashOption func(*multihashConfig)
+
+func WithAlg(code uint64) MultihashOption {
+	return func(mc *multihashConfig) {
+		mc.code = &code
+	}
+}
+
+func WithDigest(digest []byte) MultihashOption {
+	return func(mc *multihashConfig) {
+		mc.digest = &digest
+	}
+}
+
+type linkCfg struct {
+	version   *uint64
+	codec     *uint64
+	multihash *multihashConfig
+}
+
+type LinkOption func(*linkCfg)
+
+func WithVersion(version uint64) LinkOption {
+	return func(lc *linkCfg) {
+		lc.version = &version
+	}
+}
+
+func WithCodec(codec uint64) LinkOption {
+	return func(lc *linkCfg) {
+		lc.codec = &codec
+	}
+}
+
+func WithMultihashConfig(opts ...MultihashOption) LinkOption {
+	return func(lc *linkCfg) {
+		mc := &multihashConfig{}
+		for _, opt := range opts {
+			opt(mc)
+		}
+		lc.multihash = mc
+	}
+}
+
+func Link(opts ...LinkOption) Reader[any, ipld.Link] {
+	lc := &linkCfg{}
+	for _, opt := range opts {
+		opt(lc)
+	}
+	return linkReader{lc}
+}

--- a/core/schema/link_test.go
+++ b/core/schema/link_test.go
@@ -1,0 +1,110 @@
+package schema_test
+
+import (
+	"fmt"
+	"iter"
+	"maps"
+	"regexp"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+	"github.com/multiformats/go-base32"
+	mh "github.com/multiformats/go-multihash"
+	"github.com/storacha-network/go-ucanto/core/iterable"
+	"github.com/storacha-network/go-ucanto/core/schema"
+	"github.com/storacha-network/go-ucanto/testing/helpers"
+	"github.com/stretchr/testify/require"
+)
+
+func NewSet[T comparable](list iter.Seq[T]) iter.Seq[T] {
+	set := make(map[T]struct{})
+	for elem := range list {
+		set[elem] = struct{}{}
+	}
+	return maps.Keys(set)
+}
+func TestReadLink(t *testing.T) {
+	fixtures := map[string]cid.Cid{
+		"pb":          cid.MustParse("QmTgnQBKj7eTV7ohraBCmh1DLwerUd2X9Rxzgf3gyMJbC8"),
+		"cbor":        cid.MustParse("bafyreieuo63r3y2nuycaq4b3q2xvco3nprlxiwzcfp4cuupgaywat3z6mq"),
+		"rawIdentity": cid.MustParse("bafkqaaa"),
+		"ipns":        cid.MustParse("k2k4r8kuj2bs2l996lhjx8rc727xlvthtak8o6eia3qm5adxvs5k84gf"),
+		"sha512":      cid.MustParse("kgbuwaen1jrbjip6iwe9mqg54spvuucyz7f5jho2tkc2o0c7xzqwpxtogbyrwck57s9is6zqlwt9rsxbuvszym10nbaxt9jn7sf4eksqd"),
+	}
+
+	links := maps.Values(fixtures)
+	versions := NewSet(iterable.Map(func(c cid.Cid) uint64 { return c.Version() }, maps.Values(fixtures)))
+	codecs := NewSet(iterable.Map(func(c cid.Cid) uint64 { return c.Prefix().Codec }, maps.Values(fixtures)))
+	algs := NewSet(iterable.Map(func(c cid.Cid) uint64 { return c.Prefix().MhType }, maps.Values(fixtures)))
+	digests := NewSet(iterable.Map(func(c cid.Cid) string {
+		h := c.Hash()
+		dh := helpers.Must(mh.Decode(h))
+		return string(dh.Digest)
+	}, maps.Values(fixtures)))
+
+	for link := range links {
+		t.Run(fmt.Sprintf("%s ➡ schema.Link()", link), func(t *testing.T) {
+			output, err := schema.Link().Read(basicnode.NewLink(cidlink.Link{Cid: link}))
+			require.NoError(t, err)
+			require.Equal(t, output, cidlink.Link{Cid: link}, link.String())
+		})
+
+		for version := range versions {
+			t.Run(fmt.Sprintf("%s ➡ schema.Link(WithVersion(%d))", link, version), func(t *testing.T) {
+				reader := schema.Link(schema.WithVersion(version))
+				output, err := reader.Read(basicnode.NewLink(cidlink.Link{Cid: link}))
+				if link.Version() == version {
+					require.NoError(t, err)
+					require.Equal(t, output, cidlink.Link{Cid: link})
+				} else {
+					require.Error(t, err)
+					require.Contains(t, err.Error(), "Expected link to be CID version")
+				}
+			})
+		}
+
+		for codec := range codecs {
+			t.Run(fmt.Sprintf("%s ➡ schema.Link(WithCodec(%d))", link, codec), func(t *testing.T) {
+				reader := schema.Link(schema.WithCodec(codec))
+				output, err := reader.Read(basicnode.NewLink(cidlink.Link{Cid: link}))
+				if link.Prefix().Codec == codec {
+					require.NoError(t, err)
+					require.Equal(t, output, cidlink.Link{Cid: link})
+				} else {
+					require.Error(t, err)
+					require.Regexp(t, helpers.Must(regexp.Compile("Expected link to be CID with .* code")), err.Error())
+				}
+			})
+		}
+
+		for alg := range algs {
+			t.Run(fmt.Sprintf("%s ➡ schema.Link(WithMultihashConfig(WithAlg(%d)))", link, alg), func(t *testing.T) {
+				reader := schema.Link(schema.WithMultihashConfig(schema.WithAlg(alg)))
+				output, err := reader.Read(basicnode.NewLink(cidlink.Link{Cid: link}))
+				if link.Prefix().MhType == alg {
+					require.NoError(t, err)
+					require.Equal(t, output, cidlink.Link{Cid: link})
+				} else {
+					require.Error(t, err)
+					require.Regexp(t, helpers.Must(regexp.Compile("Expected link to be CID with .* hashing algorithm")), err.Error())
+				}
+			})
+		}
+
+		for digest := range digests {
+			t.Run(fmt.Sprintf("%s ➡ schema.Link(WithMultihashConfig(WithDigest(%s)))", link, base32.StdEncoding.EncodeToString([]byte(digest))), func(t *testing.T) {
+				reader := schema.Link(schema.WithMultihashConfig(schema.WithDigest([]byte(digest))))
+				output, err := reader.Read(basicnode.NewLink(cidlink.Link{Cid: link}))
+				if string(helpers.Must(mh.Decode(link.Hash())).Digest) == digest {
+					require.NoError(t, err)
+					require.Equal(t, output, cidlink.Link{Cid: link})
+				} else {
+					require.Error(t, err)
+					require.Regexp(t, helpers.Must(regexp.Compile("Expected link with .* hash digest")), err.Error())
+				}
+			})
+		}
+	}
+}

--- a/core/schema/mapped.go
+++ b/core/schema/mapped.go
@@ -1,0 +1,21 @@
+package schema
+
+import "github.com/storacha-network/go-ucanto/core/result/failure"
+
+type mapped[I, O, O2 any] struct {
+	reader    Reader[I, O]
+	converter func(O) (O2, failure.Failure)
+}
+
+func (m mapped[I, O, O2]) Read(i I) (O2, failure.Failure) {
+	o, err := m.reader.Read(i)
+	if err != nil {
+		var o2 O2
+		return o2, err
+	}
+	return m.converter(o)
+}
+
+func Mapped[I, O, O2 any](reader Reader[I, O], converter func(O) (O2, failure.Failure)) Reader[I, O2] {
+	return mapped[I, O, O2]{reader, converter}
+}

--- a/core/schema/mapped_test.go
+++ b/core/schema/mapped_test.go
@@ -1,0 +1,81 @@
+package schema_test
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
+	"github.com/storacha-network/go-ucanto/core/result/failure"
+	"github.com/storacha-network/go-ucanto/core/schema"
+	"github.com/storacha-network/go-ucanto/testing/helpers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadStruct(t *testing.T) {
+	type TestStruct struct {
+		Url string
+	}
+
+	ts := helpers.Must(ipld.LoadSchemaBytes([]byte(`
+		type TestStruct struct {
+			url String
+		}
+	`)))
+
+	type URLStruct struct {
+		Url url.URL
+	}
+
+	converter := func(ts TestStruct) (URLStruct, failure.Failure) {
+		url, err := url.Parse(ts.Url)
+		if err != nil {
+			return URLStruct{}, failure.FromError(err)
+		}
+		return URLStruct{Url: *url}, nil
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		np := basicnode.Prototype.Any
+		nb := np.NewBuilder()
+		ma := helpers.Must(nb.BeginMap(2))
+		ma.AssembleKey().AssignString("url")
+		ma.AssembleValue().AssignString("http://www.yahoo.com")
+		ma.Finish()
+		nd := nb.Build()
+
+		res, err := schema.Mapped(schema.Struct[TestStruct](ts.TypeByName("TestStruct"), nil), converter).Read(nd)
+		require.NoError(t, err)
+		fmt.Printf("%+v\n", res)
+		require.Equal(t, res.Url.Host, "www.yahoo.com")
+	})
+
+	t.Run("Failure, underlying reader", func(t *testing.T) {
+		np := basicnode.Prototype.Any
+		nb := np.NewBuilder()
+		ma := helpers.Must(nb.BeginMap(2))
+		ma.AssembleKey().AssignString("foo")
+		ma.AssembleValue().AssignString("bar")
+		ma.Finish()
+		nd := nb.Build()
+
+		_, err := schema.Mapped(schema.Struct[TestStruct](ts.TypeByName("TestStruct"), nil), converter).Read(nd)
+		require.Error(t, err)
+		fmt.Printf("%+v\n", err)
+		require.Equal(t, err.Name(), "SchemaError")
+	})
+	t.Run("Failure, conversion", func(t *testing.T) {
+		np := basicnode.Prototype.Any
+		nb := np.NewBuilder()
+		ma := helpers.Must(nb.BeginMap(2))
+		ma.AssembleKey().AssignString("url")
+		ma.AssembleValue().AssignString(":apple")
+		ma.Finish()
+		nd := nb.Build()
+
+		_, err := schema.Mapped(schema.Struct[TestStruct](ts.TypeByName("TestStruct"), nil), converter).Read(nd)
+		require.Error(t, err)
+		fmt.Printf("%+v\n", err)
+	})
+}

--- a/core/schema/or.go
+++ b/core/schema/or.go
@@ -1,0 +1,60 @@
+package schema
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/storacha-network/go-ucanto/core/result/failure"
+)
+
+type unionError struct {
+	failures []failure.Failure
+}
+
+func (ue unionError) Unwrap() []error {
+	errors := make([]error, 0, len(ue.failures))
+	for _, failure := range ue.failures {
+		errors = append(errors, failure)
+	}
+	return errors
+}
+
+func indent(message string) string {
+	indent := "  "
+	return indent + strings.Join(strings.Split(message, "\n"), "\n"+indent)
+}
+
+func li(message string) string {
+	return indent("- " + message)
+}
+
+func (ue unionError) Error() string {
+	return fmt.Sprintf("Value does not match any type of the union:\n%s", li(errors.Join(ue.Unwrap()...).Error()))
+}
+
+func (ue unionError) Name() string {
+	return "Union Error"
+}
+
+type orReader[I, O any] struct {
+	readers []Reader[I, O]
+}
+
+func (or orReader[I, O]) Read(input I) (O, failure.Failure) {
+	failures := make([]failure.Failure, 0, len(or.readers))
+	for _, reader := range or.readers {
+		o, err := reader.Read(input)
+		if err != nil {
+			failures = append(failures, err)
+		} else {
+			return o, nil
+		}
+	}
+	var o O
+	return o, failure.FromError(unionError{failures: failures})
+}
+
+func Or[I, O any](readers ...Reader[I, O]) Reader[I, O] {
+	return orReader[I, O]{readers}
+}

--- a/core/schema/uri.go
+++ b/core/schema/uri.go
@@ -1,0 +1,51 @@
+package schema
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/storacha-network/go-ucanto/core/result/failure"
+)
+
+type uriConfig struct {
+	protocol *string
+}
+
+type uriReader struct {
+	uc *uriConfig
+}
+
+type URIOption func(*uriConfig)
+
+func WithProtocol(protocol string) URIOption {
+	return func(uc *uriConfig) {
+		uc.protocol = &protocol
+	}
+}
+
+func (ur uriReader) Read(input any) (url.URL, failure.Failure) {
+	asString, stringOk := input.(string)
+	asUrl, urlOk := input.(url.URL)
+	if !stringOk && !urlOk {
+		return url.URL{}, NewSchemaError(fmt.Sprintf("Expected URI but got %T", input))
+	}
+	if !urlOk {
+		u, err := url.ParseRequestURI(asString)
+		if err != nil {
+			return url.URL{}, NewSchemaError("Invalid URI")
+		}
+		asUrl = *u
+	}
+	if ur.uc.protocol != nil && *ur.uc.protocol != asUrl.Scheme+":" {
+		return url.URL{}, NewSchemaError(fmt.Sprintf("Expected %s URI instead got %s", *ur.uc.protocol, asUrl.String()))
+	}
+	return asUrl, nil
+}
+
+func URI(opts ...URIOption) Reader[any, url.URL] {
+	uc := &uriConfig{}
+	for _, opt := range opts {
+		opt(uc)
+	}
+	return uriReader{uc}
+}

--- a/core/schema/uri_test.go
+++ b/core/schema/uri_test.go
@@ -1,0 +1,78 @@
+package schema_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/storacha-network/go-ucanto/core/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestURIDefaultReader(t *testing.T) {
+	testCases := []struct {
+		source   string
+		output   string
+		errMatch *regexp.Regexp
+	}{
+		{
+			source:   "",
+			errMatch: regexp.MustCompile("Invalid URI"),
+		},
+		{
+			source: "did:key:zAlice",
+			output: "did:key:zAlice",
+		},
+		{
+			source: "mailto:alice@mail.net",
+			output: "mailto:alice@mail.net",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("schema.URI.read(%s)", testCase.source), func(t *testing.T) {
+			output, err := schema.URI().Read(testCase.source)
+			if testCase.errMatch == nil {
+				require.NoError(t, err)
+				require.Equal(t, testCase.output, output.String())
+			} else {
+				require.Regexp(t, testCase.errMatch, err.Error())
+			}
+		})
+	}
+}
+
+func TestURIReaderWithProtocol(t *testing.T) {
+	testCases := []struct {
+		source   any
+		protocol string
+		output   string
+		errMatch *regexp.Regexp
+	}{
+		{nil, "did:", "", regexp.MustCompile("Expected URI but got <nil>")},
+		{"", "did:", "", regexp.MustCompile("Invalid URI")},
+		{"did:key:zAlice", "did:", "did:key:zAlice", nil},
+		{"did:key:zAlice", "mailto:", "", regexp.MustCompile("Expected mailto: URI instead got did:key:zAlice")},
+		{"mailto:alice@mail.net", "mailto:", "mailto:alice@mail.net", nil},
+		{"mailto:alice@mail.net", "did:", "", regexp.MustCompile("Expected did: URI instead got mailto:alice@mail.net")},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("schema.URI(WithProtocol(%s)).read(%s)", testCase.protocol, testCase.source), func(t *testing.T) {
+			output, err := schema.URI(schema.WithProtocol((testCase.protocol))).Read(testCase.source)
+			if testCase.errMatch == nil {
+				require.NoError(t, err)
+				require.Equal(t, testCase.output, output.String())
+			} else {
+				require.Regexp(t, testCase.errMatch, err.Error())
+			}
+		})
+	}
+	//	for (const [input, protocol, expect] of dataset) {
+	//	  test(`URI.match(${JSON.stringify({
+	//	    protocol,
+	//	  })}).read(${JSON.stringify(input)})}}`, () => {
+	//	    matchResult(URI.match({ protocol }).read(input), expect)
+	//	  })
+	//	}
+}


### PR DESCRIPTION
# Goals

More expressive schema languages. Adds Link, URI, and Or readers from js ucanto. Adds a "Mapped" reader for additional transformations (mostly on structs) and an initial read -- the reason here being that particularly in the case of structs, IPLD schemas may not always provide a schema def that is specific enough.

# Implementation

- add Mapped schema and test
- port js ucanto link schema and tests
- port js ucanto uri schema and tests
- port js ucanto or schema utility