### PR TITLE
fix: RSA signer code

### DIFF
--- a/principal/rsa/signer/signer.go
+++ b/principal/rsa/signer/signer.go
@@ -16,7 +16,7 @@ import (
 	"github.com/storacha/go-ucanto/ucan/crypto/signature"
 )
 
-const Code = 0x1300
+const Code = 0x1305
 const Name = verifier.Name
 
 const SignatureCode = verifier.SignatureCode


### PR DESCRIPTION
Copy pasta error. `0x1300` is Ed25519 signer code not RSA.

https://github.com/storacha/ucanto/blob/6de27c0f19790d9def1df2f2e299fa4f0996ded9/packages/principal/src/rsa/private-key.js#L8

Note: this was uncovered by [ucanto compatibility tests](https://github.com/storacha/ucanto-compat).