### PR TITLE
feat: raw signer

### DIFF
--- a/principal/ed25519/signer/signer.go
+++ b/principal/ed25519/signer/signer.go
@@ -112,9 +112,13 @@ func (s Ed25519Signer) Encode() []byte {
 	return s
 }
 
-func (s Ed25519Signer) Sign(msg []byte) signature.SignatureView {
+func (s Ed25519Signer) Raw() []byte {
 	pk := make(ed25519.PrivateKey, ed25519.PrivateKeySize)
 	copy(pk[0:ed25519.PublicKeySize], s[privateTagSize:pubKeyOffset])
 	copy(pk[ed25519.PrivateKeySize-ed25519.PublicKeySize:ed25519.PrivateKeySize], s[pubKeyOffset+publicTagSize:pubKeyOffset+publicTagSize+keySize])
-	return signature.NewSignatureView(signature.NewSignature(signature.EdDSA, ed25519.Sign(pk, msg)))
+	return pk
+}
+
+func (s Ed25519Signer) Sign(msg []byte) signature.SignatureView {
+	return signature.NewSignatureView(signature.NewSignature(signature.EdDSA, ed25519.Sign(s.Raw(), msg)))
 }

--- a/principal/ed25519/signer/signer_test.go
+++ b/principal/ed25519/signer/signer_test.go
@@ -1,8 +1,11 @@
 package signer
 
 import (
+	"crypto/ed25519"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateEncodeDecode(t *testing.T) {
@@ -65,4 +68,15 @@ func TestVerify(t *testing.T) {
 	if res != true {
 		t.Fatalf("verify failed")
 	}
+}
+
+func TestSignerRaw(t *testing.T) {
+	s, err := Generate()
+	require.NoError(t, err)
+
+	msg := []byte{1, 2, 3}
+	raw := s.Raw()
+	sig := ed25519.Sign(raw, msg)
+
+	require.Equal(t, s.Sign(msg).Raw(), sig)
 }

--- a/principal/lib.go
+++ b/principal/lib.go
@@ -12,6 +12,8 @@ type Signer interface {
 	Code() uint64
 	Verifier() Verifier
 	Encode() []byte
+	// Raw encodes the bytes of the private key without multiformats tags.
+	Raw() []byte
 }
 
 // Verifier is the principal that issued a UCAN. In usually represents remote

--- a/principal/rsa/signer/signer.go
+++ b/principal/rsa/signer/signer.go
@@ -111,6 +111,11 @@ func (s rsasigner) Encode() []byte {
 	return s.bytes
 }
 
+func (s rsasigner) Raw() []byte {
+	b, _ := multiformat.UntagWith(Code, s.bytes, 0)
+	return b
+}
+
 func (s rsasigner) Sign(msg []byte) signature.SignatureView {
 	hash := sha256.New()
 	hash.Write(msg)

--- a/principal/signer/signer.go
+++ b/principal/signer/signer.go
@@ -37,6 +37,10 @@ func (w wrapsgn) Encode() []byte {
 	return w.key.Encode()
 }
 
+func (w wrapsgn) Raw() []byte {
+	return w.key.Raw()
+}
+
 func (w wrapsgn) Sign(msg []byte) signature.SignatureView {
 	return w.key.Sign(msg)
 }


### PR DESCRIPTION
This PR adds a `Raw()` method to `Signer`, which allows encoding the private key without multiformats tags.

It effectively allows a signer generated here to interop with Go `crypto` and libp2p crypto.

The `Signature` type _already_ has a `Raw()` method (which does the same thing) so this is in keeping with that.