### PR TITLE
feat: attach blocks to delegation

### DIFF
--- a/core/delegation/delegate.go
+++ b/core/delegation/delegate.go
@@ -129,5 +129,5 @@ func Delegate[C ucan.CaveatBuilder](issuer ucan.Signer, audience ucan.Principal,
 		return nil, fmt.Errorf("adding delegation root to store: %s", err)
 	}
 
-	return NewDelegation(rt, bs), nil
+	return NewDelegation(rt, bs)
 }

--- a/core/delegation/delegation_test.go
+++ b/core/delegation/delegation_test.go
@@ -1,0 +1,36 @@
+package delegation
+
+import (
+	"testing"
+
+	"github.com/storacha/go-ucanto/core/ipld/block"
+	"github.com/storacha/go-ucanto/testing/fixtures"
+	"github.com/storacha/go-ucanto/testing/helpers"
+	"github.com/storacha/go-ucanto/ucan"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttach(t *testing.T) {
+	dlg, err := Delegate(
+		fixtures.Alice,
+		fixtures.Bob,
+		[]ucan.Capability[ucan.NoCaveats]{
+			ucan.NewCapability("test/attach", fixtures.Alice.DID().String(), ucan.NoCaveats{}),
+		},
+	)
+	require.NoError(t, err)
+
+	blk := block.NewBlock(helpers.RandomCID(), helpers.RandomBytes(32))
+	err = dlg.Attach(blk)
+	require.NoError(t, err)
+
+	found := false
+	for b, err := range dlg.Blocks() {
+		require.NoError(t, err)
+		if b.Link().String() == blk.Link().String() {
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
+}

--- a/core/invocation/invocation.go
+++ b/core/invocation/invocation.go
@@ -20,7 +20,7 @@ type Invocation interface {
 	delegation.Delegation
 }
 
-func NewInvocation(root ipld.Block, bs blockstore.BlockReader) Invocation {
+func NewInvocation(root ipld.Block, bs blockstore.BlockReader) (Invocation, error) {
 	return delegation.NewDelegation(root, bs)
 }
 

--- a/testing/helpers/helpers.go
+++ b/testing/helpers/helpers.go
@@ -1,5 +1,14 @@
 package helpers
 
+import (
+	crand "crypto/rand"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/multiformats/go-multihash"
+)
+
 // Must takes return values from a function and returns the non-error one. If
 // the error value is non-nil then it panics.
 func Must[T any](val T, err error) T {
@@ -7,4 +16,21 @@ func Must[T any](val T, err error) T {
 		panic(err)
 	}
 	return val
+}
+
+func RandomBytes(size int) []byte {
+	bytes := make([]byte, size)
+	_, _ = crand.Read(bytes)
+	return bytes
+}
+
+func RandomCID() datamodel.Link {
+	bytes := RandomBytes(10)
+	c, _ := cid.Prefix{
+		Version:  1,
+		Codec:    cid.Raw,
+		MhType:   multihash.SHA2_256,
+		MhLength: -1,
+	}.Sum(bytes)
+	return cidlink.Link{Cid: c}
 }

--- a/validator/lib_test.go
+++ b/validator/lib_test.go
@@ -533,7 +533,8 @@ func TestAccess(t *testing.T) {
 			bs, err := blockstore.NewBlockStore(blockstore.WithBlocks([]block.Block{rt}))
 			require.NoError(t, err)
 
-			dlg := delegation.NewDelegation(rt, bs)
+			dlg, err := delegation.NewDelegation(rt, bs)
+			require.NoError(t, err)
 
 			inv, err := storeAdd.Invoke(
 				fixtures.Bob,


### PR DESCRIPTION
This PR adds a method `Attach` to `Delegation` that allows additional blocks to be attached. The primary usecase is to allow blocks linked from capabilities or facts to be included in the delegation payload.

Note: this feature exists in JS Ucanto already and it actually validates the blocks you attach are referenced from capabilities/facts. I will open an issue to track feature parity here assuming this is approved.