### PR TITLE
feat: add delegation format and parse utility functions

### DIFF
--- a/core/delegation/delegation_test.go
+++ b/core/delegation/delegation_test.go
@@ -1,6 +1,7 @@
 package delegation
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/storacha/go-ucanto/core/ipld/block"
@@ -33,4 +34,25 @@ func TestAttach(t *testing.T) {
 		}
 	}
 	require.True(t, found)
+}
+
+func TestFormatParse(t *testing.T) {
+	dlg, err := Delegate(
+		fixtures.Alice,
+		fixtures.Bob,
+		[]ucan.Capability[ucan.NoCaveats]{
+			ucan.NewCapability("test/proof", fixtures.Alice.DID().String(), ucan.NoCaveats{}),
+		},
+	)
+	require.NoError(t, err)
+
+	formatted, err := Format(dlg)
+	require.NoError(t, err)
+
+	fmt.Println(formatted)
+
+	parsed, err := Parse(formatted)
+	require.NoError(t, err)
+
+	require.Equal(t, dlg.Link(), parsed.Link())
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/ipld/go-ipld-prime v0.21.0
 	github.com/multiformats/go-base32 v0.1.0
 	github.com/multiformats/go-multibase v0.2.0
+	github.com/multiformats/go-multicodec v0.9.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/multiformats/go-varint v0.0.7
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
Adds 2 utility functions that 1) formate a delegation to a string and 2) parse a formatted string to a delegation.

The string representation is a base64pad multibase encoded CIDv1 with CAR codec + an identity multihash.