### PR TITLE
feat: support invocations as effects

### DIFF
--- a/core/receipt/fx/fx.go
+++ b/core/receipt/fx/fx.go
@@ -23,8 +23,31 @@ func (fx effects) Join() Effect {
 	return fx.join
 }
 
-func NewEffects(fork []Effect, join Effect) Effects {
-	return effects{fork, join}
+// Option is an option configuring effects.
+type Option func(fx *effects) error
+
+// WithFork configures the forks for the receipt.
+func WithFork(forks ...Effect) Option {
+	return func(fx *effects) error {
+		fx.fork = forks
+		return nil
+	}
+}
+
+// WithJoin configures the join for the receipt.
+func WithJoin(join Effect) Option {
+	return func(fx *effects) error {
+		fx.join = join
+		return nil
+	}
+}
+
+func NewEffects(opts ...Option) Effects {
+	var fx effects
+	for _, opt := range opts {
+		opt(&fx)
+	}
+	return fx
 }
 
 // Effect is either an invocation or a link to one.

--- a/core/receipt/fx/fx.go
+++ b/core/receipt/fx/fx.go
@@ -1,0 +1,55 @@
+package fx
+
+import (
+	"github.com/storacha/go-ucanto/core/invocation"
+	"github.com/storacha/go-ucanto/ucan"
+)
+
+type Effects interface {
+	Fork() []Effect
+	Join() Effect
+}
+
+type effects struct {
+	fork []Effect
+	join Effect
+}
+
+func (fx effects) Fork() []Effect {
+	return fx.fork
+}
+
+func (fx effects) Join() Effect {
+	return fx.join
+}
+
+func NewEffects(fork []Effect, join Effect) Effects {
+	return effects{fork, join}
+}
+
+// Effect is either an invocation or a link to one.
+type Effect struct {
+	invocation invocation.Invocation
+	link       ucan.Link
+}
+
+// Invocation returns the invocation if it is available.
+func (e Effect) Invocation() (invocation.Invocation, bool) {
+	return e.invocation, e.invocation != nil
+}
+
+// Link returns the invocation root link.
+func (e Effect) Link() ucan.Link {
+	if e.invocation != nil {
+		return e.invocation.Link()
+	}
+	return e.link
+}
+
+func FromLink(link ucan.Link) Effect {
+	return Effect{nil, link}
+}
+
+func FromInvocation(invocation invocation.Invocation) Effect {
+	return Effect{invocation, nil}
+}

--- a/core/receipt/receipt.go
+++ b/core/receipt/receipt.go
@@ -100,7 +100,7 @@ func (r *receipt[O, X]) Fx() fx.Effects {
 		}
 	}
 
-	return fx.NewEffects(fork, join)
+	return fx.NewEffects(fx.WithFork(fork...), fx.WithJoin(join))
 }
 
 func (r *receipt[O, X]) Issuer() ucan.Principal {

--- a/core/receipt/receipt_test.go
+++ b/core/receipt/receipt_test.go
@@ -1,0 +1,85 @@
+package receipt
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/storacha/go-ucanto/core/invocation"
+	"github.com/storacha/go-ucanto/core/invocation/ran"
+	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt/fx"
+	"github.com/storacha/go-ucanto/core/result"
+	"github.com/storacha/go-ucanto/core/result/ok"
+	"github.com/storacha/go-ucanto/testing/fixtures"
+	"github.com/storacha/go-ucanto/testing/helpers"
+	"github.com/storacha/go-ucanto/ucan"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEffects(t *testing.T) {
+	ran := ran.FromLink(helpers.RandomCID())
+	out := result.Ok[ok.Unit, ipld.Builder](ok.Unit{})
+
+	t.Run("as links", func(t *testing.T) {
+		f0 := fx.FromLink(helpers.RandomCID())
+		f1 := fx.FromLink(helpers.RandomCID())
+		j := fx.FromLink(helpers.RandomCID())
+
+		receipt, err := Issue(fixtures.Alice, out, ran, WithFork(f0, f1), WithJoin(j))
+		require.NoError(t, err)
+
+		effects := receipt.Fx()
+		require.True(t, slices.ContainsFunc(effects.Fork(), func(f fx.Effect) bool {
+			return f.Link().String() == f0.Link().String()
+		}))
+		require.True(t, slices.ContainsFunc(effects.Fork(), func(f fx.Effect) bool {
+			return f.Link().String() == f1.Link().String()
+		}))
+		require.Equal(t, effects.Join().Link(), j.Link())
+	})
+
+	t.Run("as invocations", func(t *testing.T) {
+		i0, err := invocation.Invoke(
+			fixtures.Alice,
+			fixtures.Bob,
+			ucan.NewCapability("fx/0", fixtures.Alice.DID().String(), ucan.NoCaveats{}),
+		)
+		require.NoError(t, err)
+		i1, err := invocation.Invoke(
+			fixtures.Alice,
+			fixtures.Mallory,
+			ucan.NewCapability("fx/1", fixtures.Alice.DID().String(), ucan.NoCaveats{}),
+		)
+		require.NoError(t, err)
+		i2, err := invocation.Invoke(
+			fixtures.Mallory,
+			fixtures.Bob,
+			ucan.NewCapability("fx/2", fixtures.Alice.DID().String(), ucan.NoCaveats{}),
+		)
+		require.NoError(t, err)
+
+		f0 := fx.FromInvocation(i0)
+		f1 := fx.FromInvocation(i1)
+		j := fx.FromInvocation(i2)
+
+		receipt, err := Issue(fixtures.Alice, out, ran, WithFork(f0, f1), WithJoin(j))
+		require.NoError(t, err)
+
+		effects := receipt.Fx()
+		require.True(t, slices.ContainsFunc(effects.Fork(), func(f fx.Effect) bool {
+			return f.Link().String() == f0.Link().String()
+		}))
+		require.True(t, slices.ContainsFunc(effects.Fork(), func(f fx.Effect) bool {
+			return f.Link().String() == f1.Link().String()
+		}))
+		require.Equal(t, effects.Join().Link(), j.Link())
+
+		for _, effect := range effects.Fork() {
+			_, ok := effect.Invocation()
+			require.True(t, ok)
+		}
+
+		_, ok := effects.Join().Invocation()
+		require.True(t, ok)
+	})
+}

--- a/server/handler.go
+++ b/server/handler.go
@@ -3,7 +3,7 @@ package server
 import (
 	"github.com/storacha/go-ucanto/core/invocation"
 	"github.com/storacha/go-ucanto/core/ipld"
-	"github.com/storacha/go-ucanto/core/receipt"
+	"github.com/storacha/go-ucanto/core/receipt/fx"
 	"github.com/storacha/go-ucanto/core/result"
 	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/server/transaction"
@@ -11,7 +11,7 @@ import (
 	"github.com/storacha/go-ucanto/validator"
 )
 
-type HandlerFunc[C any, O ipld.Builder] func(capability ucan.Capability[C], invocation invocation.Invocation, context InvocationContext) (out O, fx receipt.Effects, err error)
+type HandlerFunc[C any, O ipld.Builder] func(capability ucan.Capability[C], invocation invocation.Invocation, context InvocationContext) (out O, fx fx.Effects, err error)
 
 // Provide is used to define given capability provider. It decorates the passed
 // handler and takes care of UCAN validation. It only calls the handler

--- a/server/server.go
+++ b/server/server.go
@@ -287,7 +287,7 @@ func Run(server Server, invocation ServiceInvocation) (receipt.AnyReceipt, error
 	fx := tx.Fx()
 	var opts []receipt.Option
 	if fx != nil {
-		opts = append(opts, receipt.WithJoin(fx.Join()), receipt.WithForks(fx.Fork()))
+		opts = append(opts, receipt.WithJoin(fx.Join()), receipt.WithFork(fx.Fork()...))
 	}
 
 	rcpt, err := receipt.Issue(server.ID(), tx.Out(), ran.FromInvocation(invocation), opts...)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/storacha/go-ucanto/core/invocation"
 	"github.com/storacha/go-ucanto/core/ipld"
 	"github.com/storacha/go-ucanto/core/receipt"
+	"github.com/storacha/go-ucanto/core/receipt/fx"
 	"github.com/storacha/go-ucanto/core/result"
 	fdm "github.com/storacha/go-ucanto/core/result/failure/datamodel"
 	"github.com/storacha/go-ucanto/core/schema"
@@ -127,7 +128,7 @@ func TestExecute(t *testing.T) {
 			fixtures.Service,
 			WithServiceMethod(
 				uploadadd.Can(),
-				Provide(uploadadd, func(cap ucan.Capability[uploadAddCaveats], inv invocation.Invocation, ctx InvocationContext) (uploadAddSuccess, receipt.Effects, error) {
+				Provide(uploadadd, func(cap ucan.Capability[uploadAddCaveats], inv invocation.Invocation, ctx InvocationContext) (uploadAddSuccess, fx.Effects, error) {
 					return uploadAddSuccess{Root: cap.Nb().Root, Status: "done"}, nil, nil
 				}),
 			),
@@ -173,7 +174,7 @@ func TestExecute(t *testing.T) {
 			fixtures.Service,
 			WithServiceMethod(
 				uploadadd.Can(),
-				Provide(uploadadd, func(cap ucan.Capability[uploadAddCaveats], inv invocation.Invocation, ctx InvocationContext) (uploadAddSuccess, receipt.Effects, error) {
+				Provide(uploadadd, func(cap ucan.Capability[uploadAddCaveats], inv invocation.Invocation, ctx InvocationContext) (uploadAddSuccess, fx.Effects, error) {
 					return uploadAddSuccess{Root: cap.Nb().Root, Status: "done"}, nil, nil
 				}),
 			),
@@ -257,7 +258,7 @@ func TestExecute(t *testing.T) {
 			fixtures.Service,
 			WithServiceMethod(
 				uploadadd.Can(),
-				Provide(uploadadd, func(cap ucan.Capability[uploadAddCaveats], inv invocation.Invocation, ctx InvocationContext) (uploadAddSuccess, receipt.Effects, error) {
+				Provide(uploadadd, func(cap ucan.Capability[uploadAddCaveats], inv invocation.Invocation, ctx InvocationContext) (uploadAddSuccess, fx.Effects, error) {
 					return uploadAddSuccess{}, nil, fmt.Errorf("test error")
 				}),
 			),

--- a/server/transaction/transaction.go
+++ b/server/transaction/transaction.go
@@ -1,8 +1,7 @@
 package transaction
 
 import (
-	"github.com/storacha/go-ucanto/core/ipld"
-	"github.com/storacha/go-ucanto/core/receipt"
+	"github.com/storacha/go-ucanto/core/receipt/fx"
 	"github.com/storacha/go-ucanto/core/result"
 )
 
@@ -10,48 +9,31 @@ import (
 // return results that have effects.
 type Transaction[O any, X any] interface {
 	Out() result.Result[O, X]
-	Fx() receipt.Effects
+	Fx() fx.Effects
 }
 
 type transaction[O, X any] struct {
 	out result.Result[O, X]
-	fx  receipt.Effects
+	fx  fx.Effects
 }
 
 func (t transaction[O, X]) Out() result.Result[O, X] {
 	return t.out
 }
 
-func (t transaction[O, X]) Fx() receipt.Effects {
+func (t transaction[O, X]) Fx() fx.Effects {
 	return t.fx
-}
-
-type effects struct {
-	fork []ipld.Link
-	join ipld.Link
-}
-
-func (fx effects) Fork() []ipld.Link {
-	return fx.fork
-}
-
-func (fx effects) Join() ipld.Link {
-	return fx.join
-}
-
-func NewEffects(fork []ipld.Link, join ipld.Link) receipt.Effects {
-	return effects{fork, join}
 }
 
 // Option is an option configuring a transaction.
 type Option func(cfg *txConfig)
 
 type txConfig struct {
-	fx receipt.Effects
+	fx fx.Effects
 }
 
 // WithEffects configures the effects for the receipt.
-func WithEffects(fx receipt.Effects) Option {
+func WithEffects(fx fx.Effects) Option {
 	return func(cfg *txConfig) {
 		cfg.fx = fx
 	}


### PR DESCRIPTION
This PR allows completed effects to be included in a receipt. Similar to [`Ran`](https://github.com/storacha/go-ucanto/blob/main/core/invocation/ran/ran.go), an effect is now a union type - a link OR an invocation.

This allows a location commitment to be returned from a `blob/accept` invocation. 🤔 Not sure I agree with using effects for this, but this is how it is done currently.