### PR TITLE
feat(ipld): pass bindnode opts

### DIFF
--- a/core/ipld/block/block.go
+++ b/core/ipld/block/block.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/node/bindnode"
 	"github.com/ipld/go-ipld-prime/schema"
 	"github.com/storacha/go-ucanto/core/ipld/codec"
 	"github.com/storacha/go-ucanto/core/ipld/hash"
@@ -34,8 +35,8 @@ func NewBlock(link ipld.Link, bytes []byte) Block {
 	return &block{link, bytes}
 }
 
-func Encode(value any, typ schema.Type, codec codec.Encoder, hasher hash.Hasher) (Block, error) {
-	b, err := codec.Encode(value, typ)
+func Encode(value any, typ schema.Type, codec codec.Encoder, hasher hash.Hasher, opts ...bindnode.Option) (Block, error) {
+	b, err := codec.Encode(value, typ, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +50,8 @@ func Encode(value any, typ schema.Type, codec codec.Encoder, hasher hash.Hasher)
 	return NewBlock(l, b), nil
 }
 
-func Decode(block Block, bind any, typ schema.Type, codec codec.Decoder, hasher hash.Hasher) error {
-	err := codec.Decode(block.Bytes(), bind, typ)
+func Decode(block Block, bind any, typ schema.Type, codec codec.Decoder, hasher hash.Hasher, opts ...bindnode.Option) error {
+	err := codec.Decode(block.Bytes(), bind, typ, opts...)
 	if err != nil {
 		return err
 	}

--- a/core/ipld/codec/cbor/cbor.go
+++ b/core/ipld/codec/cbor/cbor.go
@@ -3,6 +3,7 @@ package cbor
 import (
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/dagcbor"
+	"github.com/ipld/go-ipld-prime/node/bindnode"
 	"github.com/ipld/go-ipld-prime/schema"
 )
 
@@ -14,21 +15,21 @@ func (codec) Code() uint64 {
 	return Code
 }
 
-func (codec) Encode(val any, typ schema.Type) ([]byte, error) {
-	return Encode(val, typ)
+func (codec) Encode(val any, typ schema.Type, opts ...bindnode.Option) ([]byte, error) {
+	return Encode(val, typ, opts...)
 }
 
-func (codec) Decode(b []byte, bind any, typ schema.Type) error {
-	return Decode(b, bind, typ)
+func (codec) Decode(b []byte, bind any, typ schema.Type, opts ...bindnode.Option) error {
+	return Decode(b, bind, typ, opts...)
 }
 
 var Codec = codec{}
 
-func Encode(val any, typ schema.Type) ([]byte, error) {
-	return ipld.Marshal(dagcbor.Encode, val, typ)
+func Encode(val any, typ schema.Type, opts ...bindnode.Option) ([]byte, error) {
+	return ipld.Marshal(dagcbor.Encode, val, typ, opts...)
 }
 
-func Decode(b []byte, bind any, typ schema.Type) error {
-	_, err := ipld.Unmarshal(b, dagcbor.Decode, bind, typ)
+func Decode(b []byte, bind any, typ schema.Type, opts ...bindnode.Option) error {
+	_, err := ipld.Unmarshal(b, dagcbor.Decode, bind, typ, opts...)
 	return err
 }

--- a/core/ipld/codec/codec.go
+++ b/core/ipld/codec/codec.go
@@ -1,15 +1,16 @@
 package codec
 
 import (
+	"github.com/ipld/go-ipld-prime/node/bindnode"
 	"github.com/ipld/go-ipld-prime/schema"
 )
 
 type Encoder interface {
 	Code() uint64
-	Encode(value any, typ schema.Type) ([]byte, error)
+	Encode(value any, typ schema.Type, opts ...bindnode.Option) ([]byte, error)
 }
 
 type Decoder interface {
 	Code() uint64
-	Decode(bytes []byte, bind any, typ schema.Type) error
+	Decode(bytes []byte, bind any, typ schema.Type, opts ...bindnode.Option) error
 }

--- a/core/ipld/codec/json/json.go
+++ b/core/ipld/codec/json/json.go
@@ -3,6 +3,7 @@ package json
 import (
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/dagjson"
+	"github.com/ipld/go-ipld-prime/node/bindnode"
 	"github.com/ipld/go-ipld-prime/schema"
 )
 
@@ -14,21 +15,21 @@ func (codec) Code() uint64 {
 	return Code
 }
 
-func (codec) Encode(val any, typ schema.Type) ([]byte, error) {
-	return Encode(val, typ)
+func (codec) Encode(val any, typ schema.Type, opts ...bindnode.Option) ([]byte, error) {
+	return Encode(val, typ, opts...)
 }
 
-func (codec) Decode(b []byte, bind any, typ schema.Type) error {
-	return Decode(b, bind, typ)
+func (codec) Decode(b []byte, bind any, typ schema.Type, opts ...bindnode.Option) error {
+	return Decode(b, bind, typ, opts...)
 }
 
 var Codec = codec{}
 
-func Encode(val any, typ schema.Type) ([]byte, error) {
-	return ipld.Marshal(dagjson.Encode, val, typ)
+func Encode(val any, typ schema.Type, opts ...bindnode.Option) ([]byte, error) {
+	return ipld.Marshal(dagjson.Encode, val, typ, opts...)
 }
 
-func Decode(b []byte, bind any, typ schema.Type) error {
-	_, err := ipld.Unmarshal(b, dagjson.Decode, bind, typ)
+func Decode(b []byte, bind any, typ schema.Type, opts ...bindnode.Option) error {
+	_, err := ipld.Unmarshal(b, dagjson.Decode, bind, typ, opts...)
 	return err
 }

--- a/core/ipld/lib.go
+++ b/core/ipld/lib.go
@@ -20,7 +20,7 @@ type Builder interface {
 }
 
 // WrapWithRecovery behaves like bindnode.Wrap but converts panics into errors
-func WrapWithRecovery(ptrVal interface{}, typ schema.Type) (nd Node, err error) {
+func WrapWithRecovery(ptrVal interface{}, typ schema.Type, opts ...bindnode.Option) (nd Node, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if asStr, ok := r.(string); ok {
@@ -32,6 +32,6 @@ func WrapWithRecovery(ptrVal interface{}, typ schema.Type) (nd Node, err error) 
 			}
 		}
 	}()
-	nd = bindnode.Wrap(ptrVal, typ)
+	nd = bindnode.Wrap(ptrVal, typ, opts...)
 	return
 }

--- a/core/ipld/rebind.go
+++ b/core/ipld/rebind.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Rebind takes a Node and binds it to the Go type according to the passed schema.
-func Rebind[T any](nd datamodel.Node, typ schema.Type) (ptrVal T, err error) {
+func Rebind[T any](nd datamodel.Node, typ schema.Type, opts ...bindnode.Option) (ptrVal T, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if asStr, ok := r.(string); ok {
@@ -27,7 +27,7 @@ func Rebind[T any](nd datamodel.Node, typ schema.Type) (ptrVal T, err error) {
 	}
 
 	var nilbind T
-	np := bindnode.Prototype(&nilbind, typ)
+	np := bindnode.Prototype(&nilbind, typ, opts...)
 	nb := np.Representation().NewBuilder()
 	err = nb.AssignNode(nd)
 	if err != nil {

--- a/core/schema/options/options.go
+++ b/core/schema/options/options.go
@@ -1,0 +1,43 @@
+package options
+
+import (
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/node/bindnode"
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+// NamedBoolConverter is a generic version of bindnode.NamedBoolConverter
+func NamedBoolConverter[T any](typeName schema.TypeName, from func(bool) (T, error), to func(T) (bool, error)) bindnode.Option {
+	return bindnode.NamedBoolConverter(typeName, func(b bool) (interface{}, error) { return from(b) }, func(t interface{}) (bool, error) { return to(t.(T)) })
+}
+
+// NamedIntConverter is a generic version of bindnode.NamedIntConverter
+func NamedIntConverter[T any](typeName schema.TypeName, from func(int64) (T, error), to func(T) (int64, error)) bindnode.Option {
+	return bindnode.NamedIntConverter(typeName, func(i int64) (interface{}, error) { return from(i) }, func(t interface{}) (int64, error) { return to(t.(T)) })
+}
+
+// NamedFloatConverter is a generic version of bindnode.NamedFloatConverter
+func NamedFloatConverter[T any](typeName schema.TypeName, from func(float64) (T, error), to func(T) (float64, error)) bindnode.Option {
+	return bindnode.NamedFloatConverter(typeName, func(f float64) (interface{}, error) { return from(f) }, func(t interface{}) (float64, error) { return to(t.(T)) })
+}
+
+// NamedStringConverter is a generic version of bindnode.NamedStringConverter
+func NamedStringConverter[T any](typeName schema.TypeName, from func(string) (T, error), to func(T) (string, error)) bindnode.Option {
+	return bindnode.NamedStringConverter(typeName, func(s string) (interface{}, error) { return from(s) }, func(t interface{}) (string, error) { return to(t.(T)) })
+}
+
+// NamedBytesConverter is a generic version of bindnode.NamedBytesConverter
+func NamedBytesConverter[T any](typeName schema.TypeName, from func([]byte) (T, error), to func(T) ([]byte, error)) bindnode.Option {
+	return bindnode.NamedBytesConverter(typeName, func(b []byte) (interface{}, error) { return from(b) }, func(t interface{}) ([]byte, error) { return to(t.(T)) })
+}
+
+// NamedLinkConverter is a generic version of bindnode.NamedLinkConverter
+func NamedLinkConverter[T any](typeName schema.TypeName, from func(cid.Cid) (T, error), to func(T) (cid.Cid, error)) bindnode.Option {
+	return bindnode.NamedLinkConverter(typeName, func(c cid.Cid) (interface{}, error) { return from(c) }, func(t interface{}) (cid.Cid, error) { return to(t.(T)) })
+}
+
+// NamedAnyConverter is a generic version of bindnode.NamedAnyConverter
+func NamedAnyConverter[T any](typeName schema.TypeName, from func(datamodel.Node) (T, error), to func(T) (datamodel.Node, error)) bindnode.Option {
+	return bindnode.NamedAnyConverter(typeName, func(n datamodel.Node) (interface{}, error) { return from(n) }, func(t interface{}) (datamodel.Node, error) { return to(t.(T)) })
+}

--- a/core/schema/options/options.go
+++ b/core/schema/options/options.go
@@ -9,35 +9,119 @@ import (
 
 // NamedBoolConverter is a generic version of bindnode.NamedBoolConverter
 func NamedBoolConverter[T any](typeName schema.TypeName, from func(bool) (T, error), to func(T) (bool, error)) bindnode.Option {
-	return bindnode.NamedBoolConverter(typeName, func(b bool) (interface{}, error) { return from(b) }, func(t interface{}) (bool, error) { return to(t.(T)) })
+	return bindnode.NamedBoolConverter(typeName, func(b bool) (interface{}, error) {
+		t, err := from(b)
+		if err != nil {
+			return nil, err
+		}
+		return &t, nil
+	}, func(t interface{}) (bool, error) {
+		as := t.(*T)
+		if as == nil {
+			return false, nil
+		}
+		return to(*as)
+	})
 }
 
 // NamedIntConverter is a generic version of bindnode.NamedIntConverter
 func NamedIntConverter[T any](typeName schema.TypeName, from func(int64) (T, error), to func(T) (int64, error)) bindnode.Option {
-	return bindnode.NamedIntConverter(typeName, func(i int64) (interface{}, error) { return from(i) }, func(t interface{}) (int64, error) { return to(t.(T)) })
+	return bindnode.NamedIntConverter(typeName, func(i int64) (interface{}, error) {
+		t, err := from(i)
+		if err != nil {
+			return nil, err
+		}
+		return &t, nil
+	}, func(t interface{}) (int64, error) {
+		as := t.(*T)
+		if as == nil {
+			return 0, nil
+		}
+		return to(*as)
+	})
 }
 
 // NamedFloatConverter is a generic version of bindnode.NamedFloatConverter
 func NamedFloatConverter[T any](typeName schema.TypeName, from func(float64) (T, error), to func(T) (float64, error)) bindnode.Option {
-	return bindnode.NamedFloatConverter(typeName, func(f float64) (interface{}, error) { return from(f) }, func(t interface{}) (float64, error) { return to(t.(T)) })
+	return bindnode.NamedFloatConverter(typeName, func(f float64) (interface{}, error) {
+		t, err := from(f)
+		if err != nil {
+			return nil, err
+		}
+		return &t, nil
+	}, func(t interface{}) (float64, error) {
+		as := t.(*T)
+		if as == nil {
+			return 0, nil
+		}
+		return to(*as)
+	})
 }
 
 // NamedStringConverter is a generic version of bindnode.NamedStringConverter
 func NamedStringConverter[T any](typeName schema.TypeName, from func(string) (T, error), to func(T) (string, error)) bindnode.Option {
-	return bindnode.NamedStringConverter(typeName, func(s string) (interface{}, error) { return from(s) }, func(t interface{}) (string, error) { return to(t.(T)) })
+	return bindnode.NamedStringConverter(typeName, func(s string) (interface{}, error) {
+		t, err := from(s)
+		if err != nil {
+			return nil, err
+		}
+		return &t, nil
+	}, func(t interface{}) (string, error) {
+		as := t.(*T)
+		if as == nil {
+			return "", nil
+		}
+		return to(*as)
+	})
 }
 
 // NamedBytesConverter is a generic version of bindnode.NamedBytesConverter
 func NamedBytesConverter[T any](typeName schema.TypeName, from func([]byte) (T, error), to func(T) ([]byte, error)) bindnode.Option {
-	return bindnode.NamedBytesConverter(typeName, func(b []byte) (interface{}, error) { return from(b) }, func(t interface{}) ([]byte, error) { return to(t.(T)) })
+	return bindnode.NamedBytesConverter(typeName, func(b []byte) (interface{}, error) {
+		t, err := from(b)
+		if err != nil {
+			return nil, err
+		}
+		return &t, nil
+	}, func(t interface{}) ([]byte, error) {
+		as := t.(*T)
+		if as == nil {
+			return nil, nil
+		}
+		return to(*as)
+	})
 }
 
 // NamedLinkConverter is a generic version of bindnode.NamedLinkConverter
 func NamedLinkConverter[T any](typeName schema.TypeName, from func(cid.Cid) (T, error), to func(T) (cid.Cid, error)) bindnode.Option {
-	return bindnode.NamedLinkConverter(typeName, func(c cid.Cid) (interface{}, error) { return from(c) }, func(t interface{}) (cid.Cid, error) { return to(t.(T)) })
+	return bindnode.NamedLinkConverter(typeName, func(c cid.Cid) (interface{}, error) {
+		t, err := from(c)
+		if err != nil {
+			return nil, err
+		}
+		return &t, nil
+	}, func(t interface{}) (cid.Cid, error) {
+		as := t.(*T)
+		if as == nil {
+			return cid.Undef, nil
+		}
+		return to(*as)
+	})
 }
 
 // NamedAnyConverter is a generic version of bindnode.NamedAnyConverter
 func NamedAnyConverter[T any](typeName schema.TypeName, from func(datamodel.Node) (T, error), to func(T) (datamodel.Node, error)) bindnode.Option {
-	return bindnode.NamedAnyConverter(typeName, func(n datamodel.Node) (interface{}, error) { return from(n) }, func(t interface{}) (datamodel.Node, error) { return to(t.(T)) })
+	return bindnode.NamedAnyConverter(typeName, func(n datamodel.Node) (interface{}, error) {
+		t, err := from(n)
+		if err != nil {
+			return nil, err
+		}
+		return &t, nil
+	}, func(t interface{}) (datamodel.Node, error) {
+		as := t.(*T)
+		if as == nil {
+			return datamodel.Null, nil
+		}
+		return to(*as)
+	})
 }

--- a/core/schema/struct.go
+++ b/core/schema/struct.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"github.com/ipld/go-ipld-prime/node/bindnode"
 	"github.com/ipld/go-ipld-prime/schema"
 	"github.com/storacha/go-ucanto/core/ipld"
 	"github.com/storacha/go-ucanto/core/result/failure"
@@ -10,6 +11,7 @@ import (
 type strukt[T any] struct {
 	typ    schema.Type
 	policy policy.Policy
+	opts   []bindnode.Option
 }
 
 func (s strukt[T]) Read(input any) (T, failure.Failure) {
@@ -35,7 +37,7 @@ func (s strukt[T]) Read(input any) (T, failure.Failure) {
 		}
 	}
 
-	bind, err := ipld.Rebind[T](node, s.typ)
+	bind, err := ipld.Rebind[T](node, s.typ, s.opts...)
 	if err != nil {
 		return bind, NewSchemaError(err.Error())
 	}
@@ -43,6 +45,6 @@ func (s strukt[T]) Read(input any) (T, failure.Failure) {
 	return bind, nil
 }
 
-func Struct[T any](typ schema.Type, policy policy.Policy) Reader[any, T] {
-	return strukt[T]{typ, policy}
+func Struct[T any](typ schema.Type, policy policy.Policy, opts ...bindnode.Option) Reader[any, T] {
+	return strukt[T]{typ, policy, opts}
 }


### PR DESCRIPTION
# Goals

Improve ergonomics of working with schemas and structs with bindnode options

# Implementation

So here's the thing: I hade the Model extra copies being everywhere. It's fine when it's a complex class wrapping a model like in receipt, but a LOT of boilerplate when we're dealing with value objects -- namely capabilities and ok / err types on results. The thing is, most of these value objects can be used directly instead of having second version if they had just a little more logic around conversion from schemas. Fortunately, IPLD's bindnode actually has that through bindnode options, which while they're marked experimental, have been around for years and @rvagg just accepted my PR to make them work on named schema types, which means you can do a LOT with them. 

So, this PR basically just passes around bindnode opts to everything so you can use them (they're all var args). And, it adds some helper versions of bindnode opts that work with generics that are more ergonomic to use. 