### PR TITLE
fix(failure): recognize non-failures

### DIFF
--- a/core/result/failure/faillure.go
+++ b/core/result/failure/faillure.go
@@ -119,5 +119,9 @@ func FromError(err error) IPLDBuilderFailure {
 }
 
 func FromFailureModel(model datamodel.FailureModel) IPLDBuilderFailure {
+	// treat a zero value failure as a non-error
+	if (model == datamodel.FailureModel{}) {
+		return nil
+	}
 	return failure{model: model}
 }


### PR DESCRIPTION
# Goals

When unwrap results with fdm.FailureModel and wanting to generate an actual failure error, we need to recognize the zero value of fdm.Failure model as a non-error (especially with result.Map)