### PR TITLE
ci(github): set up codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,9 @@ jobs:
       run: go build -v ./...
 
     - name: Test
-      run: go test -v -cover ./...
+      run: go test -v -coverprofile=coverage.txt ./...
+
+    - name: Upload results to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,29 +5,26 @@ name: Test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
 
 jobs:
-
-  build:
+  test:
+    name: Run tests and collect coverage
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.21'
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
 
-    - name: Build
-      run: go build -v ./...
+      - name: Test
+        run: go test -v -coverprofile=coverage.txt ./...
 
-    - name: Test
-      run: go test -v -coverprofile=coverage.txt ./...
-
-    - name: Upload results to Codecov
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/storacha/go-ucanto
 
-go 1.23
+go 1.23.3
 
 require (
 	github.com/ipfs/go-cid v0.4.1


### PR DESCRIPTION
upload test coverage results to Codecov and tidy CI config a bit

ref: https://github.com/storacha/project-tracking/issues/173