### PR TITLE
feat: create ed25519 and RSA signer/verifier from raw public/private key bytes

### DIFF
--- a/did/did.go
+++ b/did/did.go
@@ -11,11 +11,11 @@ import (
 const Prefix = "did:"
 const KeyPrefix = "did:key:"
 
-const DIDCore = 0x0d1d
-const Ed25519 = 0xed
-const RSA = 0x1205
+const DIDCore = uint64(0x0d1d)
+const Ed25519 = uint64(0xed)
+const RSA = uint64(0x1205)
 
-var MethodOffset = varint.UvarintSize(uint64(DIDCore))
+var MethodOffset = varint.UvarintSize(DIDCore)
 
 type DID struct {
 	key bool

--- a/did/did.go
+++ b/did/did.go
@@ -11,11 +11,11 @@ import (
 const Prefix = "did:"
 const KeyPrefix = "did:key:"
 
-const DIDCore = uint64(0x0d1d)
-const Ed25519 = uint64(0xed)
-const RSA = uint64(0x1205)
+const DIDCore = 0x0d1d
+const Ed25519 = 0xed
+const RSA = 0x1205
 
-var MethodOffset = varint.UvarintSize(DIDCore)
+var MethodOffset = varint.UvarintSize(uint64(DIDCore))
 
 type DID struct {
 	key bool

--- a/principal/ed25519/signer/signer.go
+++ b/principal/ed25519/signer/signer.go
@@ -14,7 +14,7 @@ import (
 	"github.com/storacha/go-ucanto/ucan/crypto/signature"
 )
 
-const Code = 0x1300
+const Code = uint64(0x1300)
 const Name = verifier.Name
 
 const SignatureCode = verifier.SignatureCode
@@ -82,6 +82,17 @@ func Decode(b []byte) (principal.Signer, error) {
 	s := make(Ed25519Signer, size)
 	copy(s, b)
 
+	return s, nil
+}
+
+// FromRaw takes raw ed25519 private key bytes and tags with the ed25519 signer
+// and verifier multiformat codes, returning an ed25519 signer.
+func FromRaw(b []byte) (principal.Signer, error) {
+	s := make(Ed25519Signer, size)
+	varint.PutUvarint(s, Code)
+	copy(s[privateTagSize:privateTagSize+keySize], b[:ed25519.PrivateKeySize-ed25519.PublicKeySize])
+	varint.PutUvarint(s[pubKeyOffset:], verifier.Code)
+	copy(s[pubKeyOffset+publicTagSize:], b[ed25519.PrivateKeySize-ed25519.PublicKeySize:ed25519.PrivateKeySize])
 	return s, nil
 }
 

--- a/principal/ed25519/signer/signer.go
+++ b/principal/ed25519/signer/signer.go
@@ -88,6 +88,9 @@ func Decode(b []byte) (principal.Signer, error) {
 // FromRaw takes raw ed25519 private key bytes and tags with the ed25519 signer
 // and verifier multiformat codes, returning an ed25519 signer.
 func FromRaw(b []byte) (principal.Signer, error) {
+	if len(b) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("invalid length: %d wanted: %d", len(b), ed25519.PrivateKeySize)
+	}
 	s := make(Ed25519Signer, size)
 	varint.PutUvarint(s, Code)
 	copy(s[privateTagSize:privateTagSize+keySize], b[:ed25519.PrivateKeySize-ed25519.PublicKeySize])

--- a/principal/ed25519/signer/signer.go
+++ b/principal/ed25519/signer/signer.go
@@ -14,7 +14,7 @@ import (
 	"github.com/storacha/go-ucanto/ucan/crypto/signature"
 )
 
-const Code = uint64(0x1300)
+const Code = 0x1300
 const Name = verifier.Name
 
 const SignatureCode = verifier.SignatureCode

--- a/principal/ed25519/signer/signer_test.go
+++ b/principal/ed25519/signer/signer_test.go
@@ -82,13 +82,19 @@ func TestSignerRaw(t *testing.T) {
 }
 
 func TestFromRaw(t *testing.T) {
-	_, priv, err := ed25519.GenerateKey(nil)
-	require.NoError(t, err)
+	t.Run("round trip", func(t *testing.T) {
+		_, priv, err := ed25519.GenerateKey(nil)
+		require.NoError(t, err)
 
-	s, err := FromRaw(priv)
-	require.NoError(t, err)
+		s, err := FromRaw(priv)
+		require.NoError(t, err)
 
-	fmt.Println(s.DID())
+		require.Equal(t, priv, ed25519.PrivateKey(s.Raw()))
+	})
 
-	require.Equal(t, priv, ed25519.PrivateKey(s.Raw()))
+	t.Run("invalid length", func(t *testing.T) {
+		_, err := FromRaw([]byte{})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "invalid length")
+	})
 }

--- a/principal/ed25519/signer/signer_test.go
+++ b/principal/ed25519/signer/signer_test.go
@@ -80,3 +80,15 @@ func TestSignerRaw(t *testing.T) {
 
 	require.Equal(t, s.Sign(msg).Raw(), sig)
 }
+
+func TestFromRaw(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	s, err := FromRaw(priv)
+	require.NoError(t, err)
+
+	fmt.Println(s.DID())
+
+	require.Equal(t, priv, ed25519.PrivateKey(s.Raw()))
+}

--- a/principal/ed25519/verifier/verifier.go
+++ b/principal/ed25519/verifier/verifier.go
@@ -12,7 +12,7 @@ import (
 	"github.com/storacha/go-ucanto/ucan/crypto/signature"
 )
 
-const Code = uint64(0xed)
+const Code = 0xed
 const Name = "Ed25519"
 
 const SignatureCode = signature.EdDSA

--- a/principal/ed25519/verifier/verifier.go
+++ b/principal/ed25519/verifier/verifier.go
@@ -8,10 +8,11 @@ import (
 	"github.com/multiformats/go-varint"
 	"github.com/storacha/go-ucanto/did"
 	"github.com/storacha/go-ucanto/principal"
+	"github.com/storacha/go-ucanto/principal/multiformat"
 	"github.com/storacha/go-ucanto/ucan/crypto/signature"
 )
 
-const Code = 0xed
+const Code = uint64(0xed)
 const Name = "Ed25519"
 
 const SignatureCode = signature.EdDSA
@@ -56,6 +57,12 @@ func Decode(b []byte) (principal.Verifier, error) {
 	copy(v, b)
 
 	return v, nil
+}
+
+// FromRaw takes raw ed25519 public key bytes and tags with the ed25519 verifier
+// multiformat code, returning an ed25519 verifier.
+func FromRaw(b []byte) (principal.Verifier, error) {
+	return Ed25519Verifier(multiformat.TagWith(Code, b)), nil
 }
 
 type Ed25519Verifier []byte

--- a/principal/ed25519/verifier/verifier.go
+++ b/principal/ed25519/verifier/verifier.go
@@ -62,6 +62,9 @@ func Decode(b []byte) (principal.Verifier, error) {
 // FromRaw takes raw ed25519 public key bytes and tags with the ed25519 verifier
 // multiformat code, returning an ed25519 verifier.
 func FromRaw(b []byte) (principal.Verifier, error) {
+	if len(b) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("invalid length: %d wanted: %d", len(b), ed25519.PublicKeySize)
+	}
 	return Ed25519Verifier(multiformat.TagWith(Code, b)), nil
 }
 

--- a/principal/ed25519/verifier/verifier_test.go
+++ b/principal/ed25519/verifier/verifier_test.go
@@ -1,6 +1,12 @@
 package verifier
 
-import "testing"
+import (
+	"crypto/ed25519"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestParse(t *testing.T) {
 	str := "did:key:z6MkgZN5cRgWqesJeaZCEs7eKzyQsfpzmhnSEqTL6FZt56Ym"
@@ -11,4 +17,16 @@ func TestParse(t *testing.T) {
 	if v.DID().String() != str {
 		t.Fatalf("expected %s to equal %s", v.DID().String(), str)
 	}
+}
+
+func TestFromRaw(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	v, err := FromRaw(pub)
+	require.NoError(t, err)
+
+	fmt.Println(v.DID())
+
+	require.Equal(t, pub, ed25519.PublicKey(v.Raw()))
 }

--- a/principal/ed25519/verifier/verifier_test.go
+++ b/principal/ed25519/verifier/verifier_test.go
@@ -2,7 +2,6 @@ package verifier
 
 import (
 	"crypto/ed25519"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,13 +19,19 @@ func TestParse(t *testing.T) {
 }
 
 func TestFromRaw(t *testing.T) {
-	pub, _, err := ed25519.GenerateKey(nil)
-	require.NoError(t, err)
+	t.Run("round trip", func(t *testing.T) {
+		pub, _, err := ed25519.GenerateKey(nil)
+		require.NoError(t, err)
 
-	v, err := FromRaw(pub)
-	require.NoError(t, err)
+		v, err := FromRaw(pub)
+		require.NoError(t, err)
 
-	fmt.Println(v.DID())
+		require.Equal(t, pub, ed25519.PublicKey(v.Raw()))
+	})
 
-	require.Equal(t, pub, ed25519.PublicKey(v.Raw()))
+	t.Run("invalid length", func(t *testing.T) {
+		_, err := FromRaw([]byte{})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "invalid length")
+	})
 }

--- a/principal/rsa/signer/signer.go
+++ b/principal/rsa/signer/signer.go
@@ -16,7 +16,7 @@ import (
 	"github.com/storacha/go-ucanto/ucan/crypto/signature"
 )
 
-const Code = uint64(0x1305)
+const Code = 0x1305
 const Name = verifier.Name
 
 const SignatureCode = verifier.SignatureCode

--- a/principal/rsa/signer/signer_test.go
+++ b/principal/rsa/signer/signer_test.go
@@ -53,7 +53,5 @@ func TestFromRaw(t *testing.T) {
 	s, err := FromRaw(raw)
 	require.NoError(t, err)
 
-	fmt.Println(s.DID())
-
 	require.Equal(t, raw, s.Raw())
 }

--- a/principal/rsa/signer/signer_test.go
+++ b/principal/rsa/signer/signer_test.go
@@ -1,6 +1,9 @@
 package signer
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
 	"fmt"
 	"testing"
 
@@ -39,4 +42,18 @@ func TestVerify(t *testing.T) {
 
 	res := s0.Verifier().Verify(msg, sig)
 	require.Equal(t, true, res)
+}
+
+func TestFromRaw(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, keySize)
+	require.NoError(t, err)
+
+	raw := x509.MarshalPKCS1PrivateKey(priv)
+
+	s, err := FromRaw(raw)
+	require.NoError(t, err)
+
+	fmt.Println(s.DID())
+
+	require.Equal(t, raw, s.Raw())
 }

--- a/principal/rsa/verifier/verifier.go
+++ b/principal/rsa/verifier/verifier.go
@@ -13,7 +13,7 @@ import (
 	"github.com/storacha/go-ucanto/ucan/crypto/signature"
 )
 
-const Code = 0x1205
+const Code = uint64(0x1205)
 const Name = "RSA"
 
 const SignatureCode = signature.RS256
@@ -38,19 +38,30 @@ func Decode(b []byte) (principal.Verifier, error) {
 		return nil, fmt.Errorf("parsing public key: %s", err)
 	}
 
-	return rsaverifier{bytes: b, pubKey: pub}, nil
+	return RSAVerifier{bytes: b, pubKey: pub}, nil
 }
 
-type rsaverifier struct {
+// FromRaw takes raw RSA public key in PKCS #1, ASN.1 DER form and tags with the
+// RSA verifier multiformat code, returning an RSA verifier.
+func FromRaw(b []byte) (principal.Verifier, error) {
+	tb := multiformat.TagWith(Code, b)
+	pub, err := x509.ParsePKCS1PublicKey(b)
+	if err != nil {
+		return nil, fmt.Errorf("parsing public key: %s", err)
+	}
+	return RSAVerifier{tb, pub}, nil
+}
+
+type RSAVerifier struct {
 	bytes  []byte
 	pubKey *rsa.PublicKey
 }
 
-func (v rsaverifier) Code() uint64 {
+func (v RSAVerifier) Code() uint64 {
 	return Code
 }
 
-func (v rsaverifier) Verify(msg []byte, sig signature.Signature) bool {
+func (v RSAVerifier) Verify(msg []byte, sig signature.Signature) bool {
 	if sig.Code() != signature.RS256 {
 		return false
 	}
@@ -63,16 +74,16 @@ func (v rsaverifier) Verify(msg []byte, sig signature.Signature) bool {
 	return err == nil
 }
 
-func (v rsaverifier) DID() did.DID {
+func (v RSAVerifier) DID() did.DID {
 	id, _ := did.Decode(v.bytes)
 	return id
 }
 
-func (v rsaverifier) Encode() []byte {
+func (v RSAVerifier) Encode() []byte {
 	return v.bytes
 }
 
-func (v rsaverifier) Raw() []byte {
+func (v RSAVerifier) Raw() []byte {
 	b, _ := multiformat.UntagWith(Code, v.bytes, 0)
 	return b
 }

--- a/principal/rsa/verifier/verifier.go
+++ b/principal/rsa/verifier/verifier.go
@@ -13,7 +13,7 @@ import (
 	"github.com/storacha/go-ucanto/ucan/crypto/signature"
 )
 
-const Code = uint64(0x1205)
+const Code = 0x1205
 const Name = "RSA"
 
 const SignatureCode = signature.RS256

--- a/principal/rsa/verifier/verifier_test.go
+++ b/principal/rsa/verifier/verifier_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,8 +28,6 @@ func TestFromRaw(t *testing.T) {
 
 	v, err := FromRaw(raw)
 	require.NoError(t, err)
-
-	fmt.Println(v.DID())
 
 	require.Equal(t, raw, v.Raw())
 }

--- a/principal/rsa/verifier/verifier_test.go
+++ b/principal/rsa/verifier/verifier_test.go
@@ -1,6 +1,14 @@
 package verifier
 
-import "testing"
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestParse(t *testing.T) {
 	str := "did:key:z4MXj1wBzi9jUstyNgxg2TNN9cNWH8BzcMa5iZ9DAUiLutvQPgBu3zE385tUsbd4oVfHwFb2afSmHpKG4x8JVzESNPSCri4fgztu9FdV3FArz2gByZ9E6zKk3snQKuRjfMJTf29b4BLwGu9j7BtJnhR7bWDWvNqo2YSAwEP8UXyV1W7Meiu96v4esmv2sBLug4vkMFDKXx8bdYZNJYGQQHYrqGXRStZZYGK9xiddMutKeopr1q9UKrczbFhWbdsHW587y4p4uVfwj8evGak6Gx7ADHyQPJc5jWmmUXTzZHJwTqEXDekFkQwkfR9ycxWKnSmPcN9mnimKmuD4LMMzZbodM8Ukgo7XGW8HbiUf3utjt6carBD4c"
@@ -11,4 +19,18 @@ func TestParse(t *testing.T) {
 	if v.DID().String() != str {
 		t.Fatalf("expected %s to equal %s", v.DID().String(), str)
 	}
+}
+
+func TestFromRaw(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	raw := x509.MarshalPKCS1PublicKey(&priv.PublicKey)
+
+	v, err := FromRaw(raw)
+	require.NoError(t, err)
+
+	fmt.Println(v.DID())
+
+	require.Equal(t, raw, v.Raw())
 }


### PR DESCRIPTION
This PR adds a `FromRaw([]byte)` function to ed25519 and RSA signers and verifiers. It is a compliment to the `.Raw()` interface function that `Signer` and `Verifier` has. It allows to round trip to/from raw bytes (non-multiformats) and also create signers and verifiers from compatible raw public/private key bytes generated from other ed25519/RSA libraries.

For example, it allows an ed25519 private key created by the libp2p crypto library to be converted to a Ucanto signer.