### PR TITLE
feat: alternative audiences

### DIFF
--- a/server/error.go
+++ b/server/error.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/storacha/go-ucanto/core/ipld"
 	"github.com/storacha/go-ucanto/core/result/failure"
@@ -166,11 +167,12 @@ func NewInvocationCapabilityError(capabilities []ucan.Capability[any]) Invocatio
 }
 
 type InvalidAudienceError struct {
-	expected, actual string
+	accepted []string
+	actual   string
 }
 
 func (i InvalidAudienceError) Error() string {
-	return fmt.Sprintf("Invalid audience: expected %s, got %s", i.expected, i.actual)
+	return fmt.Sprintf("Invalid audience: accepted %s, got %s", strings.Join(i.accepted, ", "), i.actual)
 }
 
 func (i InvalidAudienceError) Name() string {
@@ -187,6 +189,6 @@ func (i InvalidAudienceError) ToIPLD() (ipld.Node, error) {
 	return ipld.WrapWithRecovery(&mdl, sdm.InvalidAudienceErrorType())
 }
 
-func NewInvalidAudienceError(expected, actual string) InvalidAudienceError {
-	return InvalidAudienceError{expected, actual}
+func NewInvalidAudienceError(actual string, accepted ...string) InvalidAudienceError {
+	return InvalidAudienceError{accepted, actual}
 }

--- a/server/error.go
+++ b/server/error.go
@@ -167,12 +167,17 @@ func NewInvocationCapabilityError(capabilities []ucan.Capability[any]) Invocatio
 }
 
 type InvalidAudienceError struct {
-	accepted []string
-	actual   string
+	expected []ucan.Principal
+	actual   ucan.Principal
 }
 
 func (i InvalidAudienceError) Error() string {
-	return fmt.Sprintf("Invalid audience: accepted %s, got %s", strings.Join(i.accepted, ", "), i.actual)
+	expectedStr := make([]string, 0, len(i.expected))
+	for _, e := range i.expected {
+		expectedStr = append(expectedStr, e.DID().String())
+	}
+
+	return fmt.Sprintf("Invalid audience: expected %s, got %s", strings.Join(expectedStr, " or "), i.actual.DID().String())
 }
 
 func (i InvalidAudienceError) Name() string {
@@ -189,6 +194,6 @@ func (i InvalidAudienceError) ToIPLD() (ipld.Node, error) {
 	return ipld.WrapWithRecovery(&mdl, sdm.InvalidAudienceErrorType())
 }
 
-func NewInvalidAudienceError(actual string, accepted ...string) InvalidAudienceError {
-	return InvalidAudienceError{accepted, actual}
+func NewInvalidAudienceError(actual ucan.Principal, expected ...ucan.Principal) InvalidAudienceError {
+	return InvalidAudienceError{expected, actual}
 }

--- a/server/handler.go
+++ b/server/handler.go
@@ -42,13 +42,8 @@ func Provide[C any, O ipld.Builder](capability validator.CapabilityParser[C], ha
 		}
 
 		if _, err := acceptedAudiences.Read(invocation.Audience().DID().String()); err != nil {
-			accepted := make([]string, 0, len(context.AlternativeAudiences())+1)
-			accepted = append(accepted, context.ID().DID().String())
-			for _, a := range context.AlternativeAudiences() {
-				accepted = append(accepted, a.DID().String())
-			}
-
-			audErr := NewInvalidAudienceError(invocation.Audience().DID().String(), accepted...)
+			expectedAudiences := append([]ucan.Principal{context.ID()}, context.AlternativeAudiences()...)
+			audErr := NewInvalidAudienceError(invocation.Audience(), expectedAudiences...)
 			return transaction.NewTransaction(result.Error[O, ipld.Builder](audErr)), nil
 		}
 

--- a/server/options.go
+++ b/server/options.go
@@ -7,6 +7,7 @@ import (
 	"github.com/storacha/go-ucanto/core/result"
 	"github.com/storacha/go-ucanto/server/transaction"
 	"github.com/storacha/go-ucanto/transport"
+	"github.com/storacha/go-ucanto/ucan"
 	"github.com/storacha/go-ucanto/validator"
 )
 
@@ -22,6 +23,7 @@ type srvConfig struct {
 	parsePrincipal        validator.PrincipalParserFunc
 	resolveDIDKey         validator.PrincipalResolverFunc
 	authorityProofs       []delegation.Delegation
+	altAudiences          []ucan.Principal
 	catch                 ErrorHandlerFunc
 }
 
@@ -109,6 +111,15 @@ func WithPrincipalResolver(fn validator.PrincipalResolverFunc) Option {
 func WithAuthorityProofs(proofs ...delegation.Delegation) Option {
 	return func(cfg *srvConfig) error {
 		cfg.authorityProofs = proofs
+		return nil
+	}
+}
+
+// WithAlternativeAudiences configures a set of alternative audiences that will be assumed by the service.
+// Invocations targeted to the service itself or any of the alternative audiences will be accepted.
+func WithAlternativeAudiences(audiences ...ucan.Principal) Option {
+	return func(cfg *srvConfig) error {
+		cfg.altAudiences = audiences
 		return nil
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -36,6 +36,9 @@ type InvocationContext interface {
 	validator.AuthorityProver
 	// ID is the DID of the service the invocation was sent to.
 	ID() principal.Signer
+
+	// AlternativeAudiences are other audiences the service will accept for invocations.
+	AlternativeAudiences() []ucan.Principal
 }
 
 // ServiceMethod is an invocation handler.
@@ -119,7 +122,7 @@ func NewServer(id principal.Signer, options ...Option) (ServerView, error) {
 		resolveDIDKey = validator.FailDIDKeyResolution
 	}
 
-	ctx := context{id, canIssue, validateAuthorization, resolveProof, parsePrincipal, resolveDIDKey, cfg.authorityProofs}
+	ctx := context{id, canIssue, validateAuthorization, resolveProof, parsePrincipal, resolveDIDKey, cfg.authorityProofs, cfg.altAudiences}
 	svr := &server{id, cfg.service, ctx, codec, catch}
 	return svr, nil
 }
@@ -137,6 +140,7 @@ type context struct {
 	parsePrincipal        validator.PrincipalParserFunc
 	resolveDIDKey         validator.PrincipalResolverFunc
 	authorityProofs       []delegation.Delegation
+	altAudiences          []ucan.Principal
 }
 
 func (ctx context) ID() principal.Signer {
@@ -165,6 +169,10 @@ func (ctx context) ResolveDIDKey(did did.DID) (did.DID, validator.UnresolvedDID)
 
 func (ctx context) AuthorityProofs() []delegation.Delegation {
 	return ctx.authorityProofs
+}
+
+func (ctx context) AlternativeAudiences() []ucan.Principal {
+	return ctx.altAudiences
 }
 
 type server struct {


### PR DESCRIPTION
Part of https://github.com/storacha/go-ucanto/issues/35

This PR ports the changes added to the JS ucanto library here: https://github.com/storacha/ucanto/pull/371

It adds a new `WithAlternativeAudiences` option that can be used when creating the server to have it accept invocations targeted to audiences different from the server's main identity.