### PR TITLE
fix: add AnyReceiptReader

### DIFF
--- a/core/receipt/datamodel/anyresult.ipldsch
+++ b/core/receipt/datamodel/anyresult.ipldsch
@@ -1,4 +1,7 @@
-type Result struct {
-	ok optional Any
-	error optional Any
-}
+type Result union {
+  | Success "ok"
+  | Error   "error"
+} representation keyed
+
+type Success any
+type Error any

--- a/core/receipt/datamodel/anyresult.ipldsch
+++ b/core/receipt/datamodel/anyresult.ipldsch
@@ -1,7 +1,4 @@
-type Result union {
-  | Success "ok"
-  | Error   "error"
-} representation keyed
-
-type Success any
-type Error any
+type Result struct {
+	ok optional Any
+	error optional Any
+}

--- a/core/receipt/datamodel/receipt.go
+++ b/core/receipt/datamodel/receipt.go
@@ -58,8 +58,8 @@ type MetaModel struct {
 }
 
 type ResultModel[O any, X any] struct {
-	Ok  *O
-	Err *X
+	Ok    *O
+	Error *X
 }
 
 // NewReceiptModelType creates a new schema.Type for a Receipt. You must

--- a/core/receipt/datamodel/receipt_test.go
+++ b/core/receipt/datamodel/receipt_test.go
@@ -57,7 +57,7 @@ func TestEncodeDecode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decoding receipt: %s", err)
 	}
-	if r1.Ocm.Out.Err != nil {
+	if r1.Ocm.Out.Error != nil {
 		t.Fatalf("result err was not nil")
 	}
 	if r1.Ocm.Out.Ok.Status != "done" {
@@ -68,7 +68,7 @@ func TestEncodeDecode(t *testing.T) {
 		Ocm: rdm.OutcomeModel[resultOk, resultErr]{
 			Ran: l,
 			Out: rdm.ResultModel[resultOk, resultErr]{
-				Err: &resultErr{Message: "boom"},
+				Error: &resultErr{Message: "boom"},
 			},
 		},
 	}
@@ -84,7 +84,7 @@ func TestEncodeDecode(t *testing.T) {
 	if r3.Ocm.Out.Ok != nil {
 		t.Fatalf("result ok was not nil")
 	}
-	if r3.Ocm.Out.Err.Message != "boom" {
+	if r3.Ocm.Out.Error.Message != "boom" {
 		t.Fatalf("error message was not boom")
 	}
 }
@@ -126,7 +126,7 @@ func TestEncodeDecoderFromTypes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decoding receipt: %s", err)
 	}
-	if r1.Ocm.Out.Err != nil {
+	if r1.Ocm.Out.Error != nil {
 		t.Fatalf("result err was not nil")
 	}
 	if r1.Ocm.Out.Ok.Status != "done" {
@@ -137,7 +137,7 @@ func TestEncodeDecoderFromTypes(t *testing.T) {
 		Ocm: rdm.OutcomeModel[resultOk, resultErr]{
 			Ran: l,
 			Out: rdm.ResultModel[resultOk, resultErr]{
-				Err: &resultErr{Message: "boom"},
+				Error: &resultErr{Message: "boom"},
 			},
 		},
 	}
@@ -153,7 +153,7 @@ func TestEncodeDecoderFromTypes(t *testing.T) {
 	if r3.Ocm.Out.Ok != nil {
 		t.Fatalf("result ok was not nil")
 	}
-	if r3.Ocm.Out.Err.Message != "boom" {
+	if r3.Ocm.Out.Error.Message != "boom" {
 		t.Fatalf("error message was not boom")
 	}
 }

--- a/core/receipt/receipt.go
+++ b/core/receipt/receipt.go
@@ -42,9 +42,9 @@ type Receipt[O, X any] interface {
 
 func toResultModel[O, X any](res result.Result[O, X]) rdm.ResultModel[O, X] {
 	return result.MatchResultR1(res, func(ok O) rdm.ResultModel[O, X] {
-		return rdm.ResultModel[O, X]{Ok: &ok, Err: nil}
+		return rdm.ResultModel[O, X]{Ok: &ok, Error: nil}
 	}, func(err X) rdm.ResultModel[O, X] {
-		return rdm.ResultModel[O, X]{Ok: nil, Err: &err}
+		return rdm.ResultModel[O, X]{Ok: nil, Error: &err}
 	})
 }
 
@@ -52,7 +52,7 @@ func fromResultModel[O, X any](resultModel rdm.ResultModel[O, X]) result.Result[
 	if resultModel.Ok != nil {
 		return result.Ok[O, X](*resultModel.Ok)
 	}
-	return result.Error[O, X](*resultModel.Err)
+	return result.Error[O, X](*resultModel.Error)
 }
 
 type receipt[O, X any] struct {
@@ -197,9 +197,9 @@ func NewReceiptReader[O, X any](resultschema []byte, opts ...bindnode.Option) (R
 	return &receiptReader[O, X]{typ, opts}, nil
 }
 
-func NewAnyReceiptReader(opts ...bindnode.Option) (ReceiptReader[ipld.Node, ipld.Node], error) {
+func NewAnyReceiptReader(opts ...bindnode.Option) ReceiptReader[ipld.Node, ipld.Node] {
 	anyReceiptType := rdm.TypeSystem().TypeByName("Receipt")
-	return &receiptReader[ipld.Node, ipld.Node]{anyReceiptType, opts}, nil
+	return &receiptReader[ipld.Node, ipld.Node]{anyReceiptType, opts}
 }
 
 func NewReceiptReaderFromTypes[O, X any](successType schema.Type, errType schema.Type, opts ...bindnode.Option) (ReceiptReader[O, X], error) {

--- a/core/receipt/receipt.go
+++ b/core/receipt/receipt.go
@@ -197,6 +197,11 @@ func NewReceiptReader[O, X any](resultschema []byte, opts ...bindnode.Option) (R
 	return &receiptReader[O, X]{typ, opts}, nil
 }
 
+func NewAnyReceiptReader(opts ...bindnode.Option) (ReceiptReader[ipld.Node, ipld.Node], error) {
+	anyReceiptType := rdm.TypeSystem().TypeByName("Receipt")
+	return &receiptReader[ipld.Node, ipld.Node]{anyReceiptType, opts}, nil
+}
+
 func NewReceiptReaderFromTypes[O, X any](successType schema.Type, errType schema.Type, opts ...bindnode.Option) (ReceiptReader[O, X], error) {
 	typ, err := rdm.NewReceiptModelFromTypes(successType, errType)
 	if err != nil {


### PR DESCRIPTION
The API was missing a way of reading receipts in a generic way.

`NewAnyReceiptReader` will read receipts no matter what actual types `Result.ok` or `Result.error` are. Using it will give you `AnyReceipt`s, which can then be used with `Rebind` to get a receipt with specific types if needed once you know what they are.