### PR TITLE
fix: export includes only delegation blocks

### DIFF
--- a/core/delegation/delegation.go
+++ b/core/delegation/delegation.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"iter"
-	"sync"
 
 	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-multibase"
@@ -18,7 +17,6 @@ import (
 	"github.com/storacha/go-ucanto/core/ipld/block"
 	"github.com/storacha/go-ucanto/core/ipld/codec/cbor"
 	"github.com/storacha/go-ucanto/core/ipld/hash/sha256"
-	"github.com/storacha/go-ucanto/core/iterable"
 	"github.com/storacha/go-ucanto/ucan"
 	"github.com/storacha/go-ucanto/ucan/crypto/signature"
 	udm "github.com/storacha/go-ucanto/ucan/datamodel/ucan"
@@ -46,23 +44,11 @@ type delegation struct {
 	blks     blockstore.BlockReader
 	atchblks blockstore.BlockStore
 	ucan     ucan.View
-	once     sync.Once
 }
 
 var _ Delegation = (*delegation)(nil)
 
 func (d *delegation) Data() ucan.View {
-	d.once.Do(func() {
-		data := udm.UCANModel{}
-		err := block.Decode(d.rt, &data, udm.Type(), cbor.Codec, sha256.Hasher)
-		if err != nil {
-			fmt.Printf("Error: decoding UCAN: %s\n", err)
-		}
-		d.ucan, err = ucan.NewUCAN(&data)
-		if err != nil {
-			fmt.Printf("Error: constructing UCAN view: %s\n", err)
-		}
-	})
 	return d.ucan
 }
 
@@ -75,7 +61,7 @@ func (d *delegation) Link() ucan.Link {
 }
 
 func (d *delegation) Blocks() iter.Seq2[ipld.Block, error] {
-	return iterable.Concat2(d.blks.Iterator(), d.atchblks.Iterator())
+	return Export(d.Root(), d.blks, d.atchblks)
 }
 
 func (d *delegation) Archive() io.Reader {
@@ -127,11 +113,15 @@ func (d *delegation) Attach(b block.Block) error {
 }
 
 func NewDelegation(root ipld.Block, bs blockstore.BlockReader) (Delegation, error) {
+	ucan, err := Decode(root)
+	if err != nil {
+		return nil, fmt.Errorf("decoding UCAN: %s", err)
+	}
 	attachments, err := blockstore.NewBlockStore()
 	if err != nil {
 		return nil, err
 	}
-	return &delegation{rt: root, blks: bs, atchblks: attachments}, nil
+	return &delegation{rt: root, ucan: ucan, blks: bs, atchblks: attachments}, nil
 }
 
 func NewDelegationView(root ipld.Link, bs blockstore.BlockReader) (Delegation, error) {
@@ -143,6 +133,63 @@ func NewDelegationView(root ipld.Link, bs blockstore.BlockReader) (Delegation, e
 		return nil, fmt.Errorf("missing delegation root block: %s", root)
 	}
 	return NewDelegation(blk, bs)
+}
+
+// Export the blocks that comprise the delegation, including all extra attached
+// blocks.
+func Export(rt ipld.Block, blks blockstore.BlockReader, atchblks blockstore.BlockReader) iter.Seq2[ipld.Block, error] {
+	return func(yield func(ipld.Block, error) bool) {
+		ucan, err := Decode(rt)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
+		for _, p := range ucan.Proofs() {
+			proofrt, ok, err := blks.Get(p)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			if !ok {
+				continue
+			}
+			for b, err := range Export(proofrt, blks, nil) {
+				if !yield(b, err) {
+					return
+				}
+				if err != nil {
+					return
+				}
+			}
+		}
+
+		if atchblks != nil {
+			for b, err := range atchblks.Iterator() {
+				if !yield(b, err) {
+					return
+				}
+				if err != nil {
+					return
+				}
+			}
+		}
+
+		yield(rt, nil)
+	}
+}
+
+func Decode(root ipld.Block) (ucan.View, error) {
+	data := udm.UCANModel{}
+	err := block.Decode(root, &data, udm.Type(), cbor.Codec, sha256.Hasher)
+	if err != nil {
+		return nil, fmt.Errorf("decoding root block: %w", err)
+	}
+	ucan, err := ucan.NewUCAN(&data)
+	if err != nil {
+		return nil, fmt.Errorf("constructing UCAN view: %w", err)
+	}
+	return ucan, nil
 }
 
 func Archive(d Delegation) io.Reader {

--- a/core/delegation/delegation_test.go
+++ b/core/delegation/delegation_test.go
@@ -28,7 +28,11 @@ func TestExport(t *testing.T) {
 		[]ucan.Capability[ucan.NoCaveats]{
 			ucan.NewCapability("test/proof", fixtures.Alice.DID().String(), ucan.NoCaveats{}),
 		},
-		WithProof(FromDelegation(prf)),
+		WithProof(
+			FromDelegation(prf),
+			// include an absent proof to prove things don't break - PUN INTENDED
+			FromLink(helpers.RandomCID()),
+		),
 	)
 	require.NoError(t, err)
 

--- a/core/delegation/delegation_test.go
+++ b/core/delegation/delegation_test.go
@@ -2,14 +2,73 @@ package delegation
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
+	"github.com/storacha/go-ucanto/core/dag/blockstore"
+	"github.com/storacha/go-ucanto/core/ipld"
 	"github.com/storacha/go-ucanto/core/ipld/block"
 	"github.com/storacha/go-ucanto/testing/fixtures"
 	"github.com/storacha/go-ucanto/testing/helpers"
 	"github.com/storacha/go-ucanto/ucan"
 	"github.com/stretchr/testify/require"
 )
+
+func TestExport(t *testing.T) {
+	prf, err := Delegate(
+		fixtures.Alice,
+		fixtures.Bob,
+		[]ucan.Capability[ucan.NoCaveats]{
+			ucan.NewCapability("test/proof", fixtures.Alice.DID().String(), ucan.NoCaveats{}),
+		},
+	)
+	dlg, err := Delegate(
+		fixtures.Bob,
+		fixtures.Mallory,
+		[]ucan.Capability[ucan.NoCaveats]{
+			ucan.NewCapability("test/proof", fixtures.Alice.DID().String(), ucan.NoCaveats{}),
+		},
+		WithProof(FromDelegation(prf)),
+	)
+	require.NoError(t, err)
+
+	bs, err := blockstore.NewBlockStore()
+	require.NoError(t, err)
+
+	var blks []ipld.Block
+	for b, err := range dlg.Blocks() {
+		require.NoError(t, err)
+		require.NoError(t, bs.Put(b))
+		blks = append(blks, b)
+	}
+	require.Len(t, blks, 2)
+	require.True(t, slices.ContainsFunc(blks, func(b ipld.Block) bool {
+		return b.Link().String() == prf.Link().String()
+	}))
+	require.True(t, slices.ContainsFunc(blks, func(b ipld.Block) bool {
+		return b.Link().String() == dlg.Link().String()
+	}))
+
+	// add an additional block to the blockstore that is not linked to by the
+	// delegation
+	otherblk := block.NewBlock(helpers.RandomCID(), helpers.RandomBytes(32))
+	err = bs.Put(otherblk)
+	require.NoError(t, err)
+
+	var exblks []ipld.Block
+	// export the delegation from the blockstore
+	for b, err := range Export(dlg.Root(), bs, nil) {
+		require.NoError(t, err)
+		exblks = append(exblks, b)
+	}
+
+	// expect exblks to have the same blocks in the same order and it should not
+	// include otherblk
+	require.Len(t, exblks, len(blks))
+	for i, b := range blks {
+		require.Equal(t, b.Link().String(), exblks[i].Link().String())
+	}
+}
 
 func TestAttach(t *testing.T) {
 	dlg, err := Delegate(

--- a/core/delegation/delegation_test.go
+++ b/core/delegation/delegation_test.go
@@ -61,7 +61,7 @@ func TestExport(t *testing.T) {
 
 	var exblks []ipld.Block
 	// export the delegation from the blockstore
-	for b, err := range Export(dlg.Root(), bs, nil) {
+	for b, err := range export(dlg.Data(), dlg.Root(), bs, nil) {
 		require.NoError(t, err)
 		exblks = append(exblks, b)
 	}


### PR DESCRIPTION
Fixes `Blocks()` function of a `Delegation` to include only the root block of the delegation, any (non-absent) proofs and any attached blocks. This is [consistent with the JS implementation](https://github.com/storacha/ucanto/blob/46612a897f3981dba272d19367fb75c6720a70cd/packages/core/src/delegation.js#L500).

Previously exporting delegation blocks would include ALL blocks in the blockstore used to instantiate the delegation. This prevents us from instantiating a delegation from a blockstore that contains multiple unrelated delegations or other blocks not relevant to the delegation.

As a bonus, the constructor is altered to fetch and decode the root block allowing it to fail with an error instead of failing later on property access and possibly causing a npe panic.