### PR TITLE
fix: `UTCUnixTimestamp` is used for seconds, actually

### DIFF
--- a/ucan/ucan.go
+++ b/ucan/ucan.go
@@ -43,7 +43,7 @@ type Link = ipld.Link
 // It MUST have format `${number}.${number}.${number}`
 type Version = string
 
-// UTCUnixTimestamp is a timestamp in milliseconds since the Unix epoch.
+// UTCUnixTimestamp is a timestamp in seconds since the Unix epoch.
 type UTCUnixTimestamp = int
 
 // https://github.com/ucan-wg/spec/#324-nonce


### PR DESCRIPTION
AFAICT, this comment is wrong, but all the code is right. Several places this is used describe it as seconds, and the `exp` field in a delegation uses seconds. It's just the comment here at the type declaration that says milliseconds.