### PR TITLE
feat!: context passing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.23'
+          go-version: '1.24'
 
       - name: Test
         run: go test -v -coverprofile=coverage.txt ./...

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ inv, _ := invocation.Invoke(signer, audience, capability, delegation.WithProofs(
 invocations := []invocation.Invocation{inv}
 
 // send the invocation(s) to the service
-resp, _ := client.Execute(invocations, conn)
+resp, _ := client.Execute(context.Background(), invocations, conn)
 
 // define datamodels for ok and error outcome
 type OkModel struct {
@@ -144,7 +144,7 @@ func createServer(signer principal.Signer) (server.ServerView, error) {
 			testecho.Can(),
 			server.Provide(
 				testecho,
-				func(cap ucan.Capability[TestEcho], inv invocation.Invocation, ctx server.InvocationContext) (TestEcho, receipt.Effects, error) {
+				func(ctx context.Context, cap ucan.Capability[TestEcho], inv invocation.Invocation, ictx server.InvocationContext) (TestEcho, receipt.Effects, error) {
 					return TestEcho{Echo: cap.Nb().Echo}, nil, nil
 				},
 			),
@@ -157,7 +157,7 @@ func main() {
 	server, _ := createServer(signer)
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		res, _ := server.Request(uhttp.NewHTTPRequest(r.Body, r.Header))
+		res, _ := server.Request(r.Context(), uhttp.NewHTTPRequest(r.Body, r.Header))
 
 		for key, vals := range res.Headers() {
 			for _, v := range vals {

--- a/client/connection.go
+++ b/client/connection.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"hash"
@@ -101,7 +102,7 @@ type ExecutionResponse interface {
 	Get(inv ucan.Link) (ucan.Link, bool)
 }
 
-func Execute(invocations []invocation.Invocation, conn Connection) (ExecutionResponse, error) {
+func Execute(ctx context.Context, invocations []invocation.Invocation, conn Connection) (ExecutionResponse, error) {
 	input, err := message.Build(invocations, nil)
 	if err != nil {
 		return nil, fmt.Errorf("building message: %s", err)
@@ -112,7 +113,7 @@ func Execute(invocations []invocation.Invocation, conn Connection) (ExecutionRes
 		return nil, fmt.Errorf("encoding message: %s", err)
 	}
 
-	res, err := conn.Channel().Request(req)
+	res, err := conn.Channel().Request(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("sending message: %s", err)
 	}

--- a/client/connection.go
+++ b/client/connection.go
@@ -105,22 +105,22 @@ type ExecutionResponse interface {
 func Execute(ctx context.Context, invocations []invocation.Invocation, conn Connection) (ExecutionResponse, error) {
 	input, err := message.Build(invocations, nil)
 	if err != nil {
-		return nil, fmt.Errorf("building message: %s", err)
+		return nil, fmt.Errorf("building message: %w", err)
 	}
 
 	req, err := conn.Codec().Encode(input)
 	if err != nil {
-		return nil, fmt.Errorf("encoding message: %s", err)
+		return nil, fmt.Errorf("encoding message: %w", err)
 	}
 
 	res, err := conn.Channel().Request(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("sending message: %s", err)
+		return nil, fmt.Errorf("sending message: %w", err)
 	}
 
 	output, err := conn.Codec().Decode(res)
 	if err != nil {
-		return nil, fmt.Errorf("decoding message: %s", err)
+		return nil, fmt.Errorf("decoding message: %w", err)
 	}
 
 	return ExecutionResponse(output), nil

--- a/core/car/car.go
+++ b/core/car/car.go
@@ -27,7 +27,7 @@ func Encode(roots []ipld.Link, blocks iter.Seq2[ipld.Block, error]) io.Reader {
 		for _, r := range roots {
 			_, cid, err := cid.CidFromBytes([]byte(r.Binary()))
 			if err != nil {
-				writer.CloseWithError(fmt.Errorf("decoding CAR root: %s: %s", r, err))
+				writer.CloseWithError(fmt.Errorf("decoding CAR root: %s: %w", r, err))
 				return
 			}
 			cids = append(cids, cid)
@@ -38,18 +38,18 @@ func Encode(roots []ipld.Link, blocks iter.Seq2[ipld.Block, error]) io.Reader {
 		}
 		hb, err := cbor.DumpObject(h)
 		if err != nil {
-			writer.CloseWithError(fmt.Errorf("writing CAR header: %s", err))
+			writer.CloseWithError(fmt.Errorf("writing CAR header: %w", err))
 			return
 		}
 		util.LdWrite(writer, hb)
 		for block, err := range blocks {
 			if err != nil {
-				writer.CloseWithError(fmt.Errorf("writing CAR blocks: %s", err))
+				writer.CloseWithError(fmt.Errorf("writing CAR blocks: %w", err))
 				return
 			}
 			err = util.LdWrite(writer, []byte(block.Link().Binary()), block.Bytes())
 			if err != nil {
-				writer.CloseWithError(fmt.Errorf("writing CAR blocks: %s", err))
+				writer.CloseWithError(fmt.Errorf("writing CAR blocks: %w", err))
 				return
 			}
 		}

--- a/core/dag/blockstore/blockstore.go
+++ b/core/dag/blockstore/blockstore.go
@@ -187,7 +187,7 @@ func WriteInto(view ipld.View, bs BlockWriter) error {
 	for b := range view.Blocks() {
 		err := bs.Put(b)
 		if err != nil {
-			return fmt.Errorf("putting proof block: %s", err)
+			return fmt.Errorf("putting proof block: %w", err)
 		}
 	}
 	return nil

--- a/core/delegation/datamodel/archive.go
+++ b/core/delegation/datamodel/archive.go
@@ -23,7 +23,7 @@ func mustLoadSchema() *schema.TypeSystem {
 		ts, err = ipld.LoadSchemaBytes(archive)
 	})
 	if err != nil {
-		panic(fmt.Errorf("failed to load IPLD schema: %s", err))
+		panic(fmt.Errorf("failed to load IPLD schema: %w", err))
 	}
 	return ts
 }

--- a/core/delegation/datamodel/archive_test.go
+++ b/core/delegation/datamodel/archive_test.go
@@ -18,13 +18,13 @@ func TestEncodeDecode(t *testing.T) {
 	}
 	mblk, err := block.Encode(&m0, adm.Type(), cbor.Codec, sha256.Hasher)
 	if err != nil {
-		t.Fatalf("encoding archive model: %w", err)
+		t.Fatalf("encoding archive model: %s", err)
 	}
 
 	m1 := adm.ArchiveModel{}
 	err = block.Decode(mblk, &m1, adm.Type(), cbor.Codec, sha256.Hasher)
 	if err != nil {
-		t.Fatalf("decoding agent message: %w", err)
+		t.Fatalf("decoding agent message: %s", err)
 	}
 
 	d1 := m1.Ucan0_9_1

--- a/core/delegation/datamodel/archive_test.go
+++ b/core/delegation/datamodel/archive_test.go
@@ -18,13 +18,13 @@ func TestEncodeDecode(t *testing.T) {
 	}
 	mblk, err := block.Encode(&m0, adm.Type(), cbor.Codec, sha256.Hasher)
 	if err != nil {
-		t.Fatalf("encoding archive model: %s", err)
+		t.Fatalf("encoding archive model: %w", err)
 	}
 
 	m1 := adm.ArchiveModel{}
 	err = block.Decode(mblk, &m1, adm.Type(), cbor.Codec, sha256.Hasher)
 	if err != nil {
-		t.Fatalf("decoding agent message: %s", err)
+		t.Fatalf("decoding agent message: %w", err)
 	}
 
 	d1 := m1.Ucan0_9_1

--- a/core/delegation/delegate.go
+++ b/core/delegation/delegate.go
@@ -116,17 +116,17 @@ func Delegate[C ucan.CaveatBuilder](issuer ucan.Signer, audience ucan.Principal,
 
 	data, err := ucan.Issue(issuer, audience, capabilities, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("issuing UCAN: %s", err)
+		return nil, fmt.Errorf("issuing UCAN: %w", err)
 	}
 
 	rt, err := block.Encode(data.Model(), udm.Type(), cbor.Codec, sha256.Hasher)
 	if err != nil {
-		return nil, fmt.Errorf("encoding UCAN: %s", err)
+		return nil, fmt.Errorf("encoding UCAN: %w", err)
 	}
 
 	err = bs.Put(rt)
 	if err != nil {
-		return nil, fmt.Errorf("adding delegation root to store: %s", err)
+		return nil, fmt.Errorf("adding delegation root to store: %w", err)
 	}
 
 	return NewDelegation(rt, bs)

--- a/core/delegation/delegation.go
+++ b/core/delegation/delegation.go
@@ -115,7 +115,7 @@ func (d *delegation) Attach(b block.Block) error {
 func NewDelegation(root ipld.Block, bs blockstore.BlockReader) (Delegation, error) {
 	ucan, err := decode(root)
 	if err != nil {
-		return nil, fmt.Errorf("decoding UCAN: %s", err)
+		return nil, fmt.Errorf("decoding UCAN: %w", err)
 	}
 	attachments, err := blockstore.NewBlockStore()
 	if err != nil {
@@ -127,7 +127,7 @@ func NewDelegation(root ipld.Block, bs blockstore.BlockReader) (Delegation, erro
 func NewDelegationView(root ipld.Link, bs blockstore.BlockReader) (Delegation, error) {
 	blk, ok, err := bs.Get(root)
 	if err != nil {
-		return nil, fmt.Errorf("getting delegation root block: %s", err)
+		return nil, fmt.Errorf("getting delegation root block: %w", err)
 	}
 	if !ok {
 		return nil, fmt.Errorf("missing delegation root block: %s", root)
@@ -201,20 +201,20 @@ func Archive(d Delegation) io.Reader {
 	)
 	if err != nil {
 		reader, _ := io.Pipe()
-		reader.CloseWithError(fmt.Errorf("hashing variant block bytes: %s", err))
+		reader.CloseWithError(fmt.Errorf("hashing variant block bytes: %w", err))
 		return reader
 	}
 	// Create a new reader that contains the new block as well as the others.
 	blks, err := blockstore.NewBlockStore(blockstore.WithBlocksIterator(d.Blocks()))
 	if err != nil {
 		reader, _ := io.Pipe()
-		reader.CloseWithError(fmt.Errorf("creating new block reader: %s", err))
+		reader.CloseWithError(fmt.Errorf("creating new block reader: %w", err))
 		return reader
 	}
 	err = blks.Put(variant)
 	if err != nil {
 		reader, _ := io.Pipe()
-		reader.CloseWithError(fmt.Errorf("adding variant block: %s", err))
+		reader.CloseWithError(fmt.Errorf("adding variant block: %w", err))
 		return reader
 	}
 	return car.Encode([]ipld.Link{variant.Link()}, blks.Iterator())
@@ -234,15 +234,15 @@ func Extract(b []byte) (Delegation, error) {
 
 	br, err := blockstore.NewBlockReader(blockstore.WithBlocksIterator(blks))
 	if err != nil {
-		return nil, fmt.Errorf("creating block reader: %s", err)
+		return nil, fmt.Errorf("creating block reader: %w", err)
 	}
 
 	rt, ok, err := br.Get(roots[0])
 	if err != nil {
-		return nil, fmt.Errorf("getting root block: %s", err)
+		return nil, fmt.Errorf("getting root block: %w", err)
 	}
 	if !ok {
-		return nil, fmt.Errorf("missing root block: %d", len(roots))
+		return nil, fmt.Errorf("missing root block: %s", roots[0])
 	}
 
 	model := adm.ArchiveModel{}
@@ -254,7 +254,7 @@ func Extract(b []byte) (Delegation, error) {
 		sha256.Hasher,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("decoding root block: %s", err)
+		return nil, fmt.Errorf("decoding root block: %w", err)
 	}
 
 	return NewDelegationView(model.Ucan0_9_1, br)

--- a/core/message/datamodel/agentmessage.go
+++ b/core/message/datamodel/agentmessage.go
@@ -23,7 +23,7 @@ func mustLoadSchema() *schema.TypeSystem {
 		ts, err = ipld.LoadSchemaBytes(agentmessage)
 	})
 	if err != nil {
-		panic(fmt.Errorf("failed to load IPLD schema: %s", err))
+		panic(fmt.Errorf("failed to load IPLD schema: %w", err))
 	}
 	return ts
 }

--- a/core/message/message.go
+++ b/core/message/message.go
@@ -140,7 +140,7 @@ func NewMessage(roots []ipld.Link, blks blockstore.BlockReader) (AgentMessage, e
 
 	rblock, ok, err := blks.Get(roots[0])
 	if err != nil {
-		return nil, fmt.Errorf("getting root block: %s", err)
+		return nil, fmt.Errorf("getting root block: %w", err)
 	}
 	if !ok {
 		return nil, fmt.Errorf("missing root block: %s", roots[0])
@@ -155,7 +155,7 @@ func NewMessage(roots []ipld.Link, blks blockstore.BlockReader) (AgentMessage, e
 		sha256.Hasher,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("decoding message: %s", err)
+		return nil, fmt.Errorf("decoding message: %w", err)
 	}
 
 	return &message{root: rblock, data: msg.UcantoMessage7, blks: blks}, nil

--- a/core/receipt/datamodel/receipt.go
+++ b/core/receipt/datamodel/receipt.go
@@ -24,7 +24,7 @@ var anyReceiptTs *schema.TypeSystem
 func init() {
 	ts, err := NewReceiptModelType(anyResultSchema)
 	if err != nil {
-		panic(fmt.Errorf("failed to load IPLD schema: %s", err))
+		panic(fmt.Errorf("failed to load IPLD schema: %w", err))
 	}
 	anyReceiptTs = ts.TypeSystem()
 }

--- a/core/receipt/receipt.go
+++ b/core/receipt/receipt.go
@@ -151,7 +151,7 @@ func (r *receipt[O, X]) Signature() signature.SignatureView {
 func NewReceipt[O, X any](root ipld.Link, blocks blockstore.BlockReader, typ schema.Type, opts ...bindnode.Option) (Receipt[O, X], error) {
 	rblock, ok, err := blocks.Get(root)
 	if err != nil {
-		return nil, fmt.Errorf("getting receipt root block: %s", err)
+		return nil, fmt.Errorf("getting receipt root block: %w", err)
 	}
 	if !ok {
 		return nil, fmt.Errorf("missing receipt root block: %s", root)
@@ -160,7 +160,7 @@ func NewReceipt[O, X any](root ipld.Link, blocks blockstore.BlockReader, typ sch
 	rmdl := rdm.ReceiptModel[O, X]{}
 	err = block.Decode(rblock, &rmdl, typ, cbor.Codec, sha256.Hasher, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("decoding receipt: %s", err)
+		return nil, fmt.Errorf("decoding receipt: %w", err)
 	}
 
 	rcpt := receipt[O, X]{
@@ -184,7 +184,7 @@ type receiptReader[O, X any] struct {
 func (rr *receiptReader[O, X]) Read(rcpt ipld.Link, blks iter.Seq2[block.Block, error]) (Receipt[O, X], error) {
 	br, err := blockstore.NewBlockReader(blockstore.WithBlocksIterator(blks))
 	if err != nil {
-		return nil, fmt.Errorf("creating block reader: %s", err)
+		return nil, fmt.Errorf("creating block reader: %w", err)
 	}
 	return NewReceipt[O, X](rcpt, br, rr.typ, rr.opts...)
 }
@@ -192,7 +192,7 @@ func (rr *receiptReader[O, X]) Read(rcpt ipld.Link, blks iter.Seq2[block.Block, 
 func NewReceiptReader[O, X any](resultschema []byte, opts ...bindnode.Option) (ReceiptReader[O, X], error) {
 	typ, err := rdm.NewReceiptModelType(resultschema)
 	if err != nil {
-		return nil, fmt.Errorf("loading receipt data model: %s", err)
+		return nil, fmt.Errorf("loading receipt data model: %w", err)
 	}
 	return &receiptReader[O, X]{typ, opts}, nil
 }
@@ -205,7 +205,7 @@ func NewAnyReceiptReader(opts ...bindnode.Option) ReceiptReader[ipld.Node, ipld.
 func NewReceiptReaderFromTypes[O, X any](successType schema.Type, errType schema.Type, opts ...bindnode.Option) (ReceiptReader[O, X], error) {
 	typ, err := rdm.NewReceiptModelFromTypes(successType, errType)
 	if err != nil {
-		return nil, fmt.Errorf("loading receipt data model: %s", err)
+		return nil, fmt.Errorf("loading receipt data model: %w", err)
 	}
 	return &receiptReader[O, X]{typ, opts}, nil
 }
@@ -357,12 +357,12 @@ func Issue[O, X ipld.Builder](issuer ucan.Signer, out result.Result[O, X], ran r
 
 	rt, err := block.Encode(&receiptModel, rdm.TypeSystem().TypeByName("Receipt"), cbor.Codec, sha256.Hasher)
 	if err != nil {
-		return nil, fmt.Errorf("encoding receipt: %s", err)
+		return nil, fmt.Errorf("encoding receipt: %w", err)
 	}
 
 	err = bs.Put(rt)
 	if err != nil {
-		return nil, fmt.Errorf("adding receipt root to store: %s", err)
+		return nil, fmt.Errorf("adding receipt root to store: %w", err)
 	}
 
 	return &receipt[ipld.Node, ipld.Node]{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/storacha/go-ucanto
 
-go 1.23.3
+go 1.24.4
 
 require (
 	github.com/ipfs/go-cid v0.4.1

--- a/principal/ed25519/signer/signer.go
+++ b/principal/ed25519/signer/signer.go
@@ -31,7 +31,7 @@ var pubKeyOffset = privateTagSize + keySize
 func Generate() (principal.Signer, error) {
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
-		return nil, fmt.Errorf("generating Ed25519 key: %s", err)
+		return nil, fmt.Errorf("generating Ed25519 key: %w", err)
 	}
 	s := make(Ed25519Signer, size)
 	varint.PutUvarint(s, Code)
@@ -44,7 +44,7 @@ func Generate() (principal.Signer, error) {
 func Parse(str string) (principal.Signer, error) {
 	_, bytes, err := multibase.Decode(str)
 	if err != nil {
-		return nil, fmt.Errorf("decoding multibase string: %s", err)
+		return nil, fmt.Errorf("decoding multibase string: %w", err)
 	}
 	return Decode(bytes)
 }
@@ -60,7 +60,7 @@ func Decode(b []byte) (principal.Signer, error) {
 
 	prc, err := varint.ReadUvarint(bytes.NewReader(b))
 	if err != nil {
-		return nil, fmt.Errorf("reading private key codec: %s", err)
+		return nil, fmt.Errorf("reading private key codec: %w", err)
 	}
 	if prc != Code {
 		return nil, fmt.Errorf("invalid private key codec: %d", prc)
@@ -68,7 +68,7 @@ func Decode(b []byte) (principal.Signer, error) {
 
 	puc, err := varint.ReadUvarint(bytes.NewReader(b[pubKeyOffset:]))
 	if err != nil {
-		return nil, fmt.Errorf("reading public key codec: %s", err)
+		return nil, fmt.Errorf("reading public key codec: %w", err)
 	}
 	if puc != verifier.Code {
 		return nil, fmt.Errorf("invalid public key codec: %d", prc)
@@ -76,7 +76,7 @@ func Decode(b []byte) (principal.Signer, error) {
 
 	_, err = verifier.Decode(b[pubKeyOffset:])
 	if err != nil {
-		return nil, fmt.Errorf("decoding public key: %s", err)
+		return nil, fmt.Errorf("decoding public key: %w", err)
 	}
 
 	s := make(Ed25519Signer, size)

--- a/principal/ed25519/verifier/verifier.go
+++ b/principal/ed25519/verifier/verifier.go
@@ -27,7 +27,7 @@ var size = publicTagSize + keySize
 func Parse(str string) (principal.Verifier, error) {
 	did, err := did.Parse(str)
 	if err != nil {
-		return nil, fmt.Errorf("parsing DID: %s", err)
+		return nil, fmt.Errorf("parsing DID: %w", err)
 	}
 	return Decode(did.Bytes())
 }
@@ -39,7 +39,7 @@ func Decode(b []byte) (principal.Verifier, error) {
 
 	prc, err := varint.ReadUvarint(bytes.NewReader(b))
 	if err != nil {
-		return nil, fmt.Errorf("reading public key codec: %s", err)
+		return nil, fmt.Errorf("reading public key codec: %w", err)
 	}
 	if prc != Code {
 		return nil, fmt.Errorf("invalid public key codec: %d", prc)
@@ -47,7 +47,7 @@ func Decode(b []byte) (principal.Verifier, error) {
 
 	puc, err := varint.ReadUvarint(bytes.NewReader(b))
 	if err != nil {
-		return nil, fmt.Errorf("reading public key codec: %s", err)
+		return nil, fmt.Errorf("reading public key codec: %w", err)
 	}
 	if puc != Code {
 		return nil, fmt.Errorf("invalid public key codec: %d", prc)

--- a/principal/rsa/signer/signer.go
+++ b/principal/rsa/signer/signer.go
@@ -27,7 +27,7 @@ const keySize = 2048
 func Generate() (principal.Signer, error) {
 	priv, err := rsa.GenerateKey(rand.Reader, keySize)
 	if err != nil {
-		return nil, fmt.Errorf("generating RSA key: %s", err)
+		return nil, fmt.Errorf("generating RSA key: %w", err)
 	}
 
 	// Next we need to encode public key, because `RSAVerifier` uses it to
@@ -36,7 +36,7 @@ func Generate() (principal.Signer, error) {
 
 	verif, err := verifier.Decode(pubbytes)
 	if err != nil {
-		return nil, fmt.Errorf("decoding public bytes: %s", err)
+		return nil, fmt.Errorf("decoding public bytes: %w", err)
 	}
 
 	// Export key in Private Key Cryptography Standards (PKCS) format and extract
@@ -51,7 +51,7 @@ func Generate() (principal.Signer, error) {
 func Parse(str string) (principal.Signer, error) {
 	_, bytes, err := multibase.Decode(str)
 	if err != nil {
-		return nil, fmt.Errorf("decoding multibase string: %s", err)
+		return nil, fmt.Errorf("decoding multibase string: %w", err)
 	}
 	return Decode(bytes)
 }
@@ -68,14 +68,14 @@ func Decode(b []byte) (principal.Signer, error) {
 
 	priv, err := x509.ParsePKCS1PrivateKey(utb)
 	if err != nil {
-		return nil, fmt.Errorf("parsing private key: %s", err)
+		return nil, fmt.Errorf("parsing private key: %w", err)
 	}
 
 	pubbytes := multiformat.TagWith(verifier.Code, x509.MarshalPKCS1PublicKey(&priv.PublicKey))
 
 	verif, err := verifier.Decode(pubbytes)
 	if err != nil {
-		return nil, fmt.Errorf("decoding public bytes: %s", err)
+		return nil, fmt.Errorf("decoding public bytes: %w", err)
 	}
 
 	return RSASigner{bytes: b, privKey: priv, verifier: verif}, nil
@@ -87,11 +87,11 @@ func FromRaw(b []byte) (principal.Signer, error) {
 	tb := multiformat.TagWith(Code, b)
 	priv, err := x509.ParsePKCS1PrivateKey(b)
 	if err != nil {
-		return nil, fmt.Errorf("parsing private key: %s", err)
+		return nil, fmt.Errorf("parsing private key: %w", err)
 	}
 	verif, err := verifier.FromRaw(x509.MarshalPKCS1PublicKey(&priv.PublicKey))
 	if err != nil {
-		return nil, fmt.Errorf("decoding public bytes: %s", err)
+		return nil, fmt.Errorf("decoding public bytes: %w", err)
 	}
 	return RSASigner{bytes: tb, privKey: priv, verifier: verif}, nil
 }

--- a/principal/rsa/verifier/verifier.go
+++ b/principal/rsa/verifier/verifier.go
@@ -22,7 +22,7 @@ const SignatureAlgorithm = "RS256"
 func Parse(str string) (principal.Verifier, error) {
 	did, err := did.Parse(str)
 	if err != nil {
-		return nil, fmt.Errorf("parsing DID: %s", err)
+		return nil, fmt.Errorf("parsing DID: %w", err)
 	}
 	return Decode(did.Bytes())
 }
@@ -35,7 +35,7 @@ func Decode(b []byte) (principal.Verifier, error) {
 
 	pub, err := x509.ParsePKCS1PublicKey(utb)
 	if err != nil {
-		return nil, fmt.Errorf("parsing public key: %s", err)
+		return nil, fmt.Errorf("parsing public key: %w", err)
 	}
 
 	return RSAVerifier{bytes: b, pubKey: pub}, nil
@@ -47,7 +47,7 @@ func FromRaw(b []byte) (principal.Verifier, error) {
 	tb := multiformat.TagWith(Code, b)
 	pub, err := x509.ParsePKCS1PublicKey(b)
 	if err != nil {
-		return nil, fmt.Errorf("parsing public key: %s", err)
+		return nil, fmt.Errorf("parsing public key: %w", err)
 	}
 	return RSAVerifier{tb, pub}, nil
 }

--- a/server/datamodel/errors.go
+++ b/server/datamodel/errors.go
@@ -19,7 +19,7 @@ var (
 func init() {
 	ts, err := ipld.LoadSchemaBytes(errorsch)
 	if err != nil {
-		panic(fmt.Errorf("failed to load IPLD schema: %s", err))
+		panic(fmt.Errorf("failed to load IPLD schema: %w", err))
 	}
 	errorTypeSystem = ts
 }

--- a/server/options.go
+++ b/server/options.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+
 	"github.com/storacha/go-ucanto/core/delegation"
 	"github.com/storacha/go-ucanto/core/invocation"
 	"github.com/storacha/go-ucanto/core/ipld"
@@ -29,8 +31,8 @@ type srvConfig struct {
 
 func WithServiceMethod[O ipld.Builder](can string, handleFunc ServiceMethod[O]) Option {
 	return func(cfg *srvConfig) error {
-		cfg.service[can] = func(input invocation.Invocation, context InvocationContext) (transaction.Transaction[ipld.Builder, ipld.Builder], error) {
-			tx, err := handleFunc(input, context)
+		cfg.service[can] = func(ctx context.Context, input invocation.Invocation, invCtx InvocationContext) (transaction.Transaction[ipld.Builder, ipld.Builder], error) {
+			tx, err := handleFunc(ctx, input, invCtx)
 			if err != nil {
 				return nil, err
 			}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -128,7 +129,7 @@ func TestExecute(t *testing.T) {
 			fixtures.Service,
 			WithServiceMethod(
 				uploadadd.Can(),
-				Provide(uploadadd, func(cap ucan.Capability[uploadAddCaveats], inv invocation.Invocation, ctx InvocationContext) (uploadAddSuccess, fx.Effects, error) {
+				Provide(uploadadd, func(ctx context.Context, cap ucan.Capability[uploadAddCaveats], inv invocation.Invocation, ictx InvocationContext) (uploadAddSuccess, fx.Effects, error) {
 					return uploadAddSuccess{Root: cap.Nb().Root, Status: "done"}, nil, nil
 				}),
 			),
@@ -140,7 +141,7 @@ func TestExecute(t *testing.T) {
 		inv, err := invocation.Invoke(fixtures.Service, fixtures.Service, cap)
 		require.NoError(t, err)
 
-		resp, err := client.Execute([]invocation.Invocation{inv}, conn)
+		resp, err := client.Execute(context.Background(), []invocation.Invocation{inv}, conn)
 		require.NoError(t, err)
 
 		// get the receipt link for the invocation from the response
@@ -174,7 +175,7 @@ func TestExecute(t *testing.T) {
 			fixtures.Service,
 			WithServiceMethod(
 				uploadadd.Can(),
-				Provide(uploadadd, func(cap ucan.Capability[uploadAddCaveats], inv invocation.Invocation, ctx InvocationContext) (uploadAddSuccess, fx.Effects, error) {
+				Provide(uploadadd, func(ctx context.Context, cap ucan.Capability[uploadAddCaveats], inv invocation.Invocation, ictx InvocationContext) (uploadAddSuccess, fx.Effects, error) {
 					return uploadAddSuccess{Root: cap.Nb().Root, Status: "done"}, nil, nil
 				}),
 			),
@@ -196,7 +197,7 @@ func TestExecute(t *testing.T) {
 		inv, err := invocation.Invoke(fixtures.Alice, fixtures.Service, cap, delegation.WithProof(prfs...))
 		require.NoError(t, err)
 
-		resp, err := client.Execute([]invocation.Invocation{inv}, conn)
+		resp, err := client.Execute(context.Background(), []invocation.Invocation{inv}, conn)
 		require.NoError(t, err)
 
 		// get the receipt link for the invocation from the response
@@ -230,7 +231,7 @@ func TestExecute(t *testing.T) {
 		)
 
 		invs := []invocation.Invocation{helpers.Must(invocation.Invoke(fixtures.Alice, fixtures.Service, capability))}
-		resp := helpers.Must(client.Execute(invs, conn))
+		resp := helpers.Must(client.Execute(context.Background(), invs, conn))
 		rcptlnk, ok := resp.Get(invs[0].Link())
 		require.True(t, ok, "missing receipt for invocation: %s", invs[0].Link())
 
@@ -258,7 +259,7 @@ func TestExecute(t *testing.T) {
 			fixtures.Service,
 			WithServiceMethod(
 				uploadadd.Can(),
-				Provide(uploadadd, func(cap ucan.Capability[uploadAddCaveats], inv invocation.Invocation, ctx InvocationContext) (uploadAddSuccess, fx.Effects, error) {
+				Provide(uploadadd, func(ctx context.Context, cap ucan.Capability[uploadAddCaveats], inv invocation.Invocation, ictx InvocationContext) (uploadAddSuccess, fx.Effects, error) {
 					return uploadAddSuccess{}, nil, fmt.Errorf("test error")
 				}),
 			),
@@ -268,7 +269,7 @@ func TestExecute(t *testing.T) {
 		rt := cidlink.Link{Cid: cid.MustParse("bafkreiem4twkqzsq2aj4shbycd4yvoj2cx72vezicletlhi7dijjciqpui")}
 		cap := uploadadd.New(fixtures.Alice.DID().String(), uploadAddCaveats{Root: rt})
 		invs := []invocation.Invocation{helpers.Must(invocation.Invoke(fixtures.Alice, fixtures.Service, cap))}
-		resp := helpers.Must(client.Execute(invs, conn))
+		resp := helpers.Must(client.Execute(context.Background(), invs, conn))
 		rcptlnk, ok := resp.Get(invs[0].Link())
 		require.True(t, ok, "missing receipt for invocation: %s", invs[0].Link())
 
@@ -296,7 +297,7 @@ func TestExecute(t *testing.T) {
 			fixtures.Service,
 			WithServiceMethod(
 				uploadadd.Can(),
-				Provide(uploadadd, func(cap ucan.Capability[uploadAddCaveats], inv invocation.Invocation, ctx InvocationContext) (uploadAddSuccess, fx.Effects, error) {
+				Provide(uploadadd, func(ctx context.Context, cap ucan.Capability[uploadAddCaveats], inv invocation.Invocation, ictx InvocationContext) (uploadAddSuccess, fx.Effects, error) {
 					return uploadAddSuccess{Root: cap.Nb().Root, Status: "done"}, nil, nil
 				}),
 			),
@@ -309,7 +310,7 @@ func TestExecute(t *testing.T) {
 		// invocation audience different from the service
 		invs := []invocation.Invocation{helpers.Must(invocation.Invoke(fixtures.Alice, fixtures.Bob, cap))}
 
-		resp, err := client.Execute(invs, conn)
+		resp, err := client.Execute(context.Background(), invs, conn)
 		require.NoError(t, err)
 
 		rcptlnk, ok := resp.Get(invs[0].Link())
@@ -338,7 +339,7 @@ func TestExecute(t *testing.T) {
 			fixtures.Service,
 			WithServiceMethod(
 				uploadadd.Can(),
-				Provide(uploadadd, func(cap ucan.Capability[uploadAddCaveats], inv invocation.Invocation, ctx InvocationContext) (uploadAddSuccess, fx.Effects, error) {
+				Provide(uploadadd, func(ctx context.Context, cap ucan.Capability[uploadAddCaveats], inv invocation.Invocation, ictx InvocationContext) (uploadAddSuccess, fx.Effects, error) {
 					return uploadAddSuccess{Root: cap.Nb().Root, Status: "done"}, nil, nil
 				}),
 			),
@@ -352,7 +353,7 @@ func TestExecute(t *testing.T) {
 		// invocation audience different from the service, but an accepted alternative audience
 		invs := []invocation.Invocation{helpers.Must(invocation.Invoke(fixtures.Alice, fixtures.Bob, cap))}
 
-		resp, err := client.Execute(invs, conn)
+		resp, err := client.Execute(context.Background(), invs, conn)
 		require.NoError(t, err)
 
 		rcptlnk, ok := resp.Get(invs[0].Link())
@@ -380,7 +381,7 @@ func TestHandle(t *testing.T) {
 		hd.Set("Accept", response.ContentType)
 
 		req := thttp.NewHTTPRequest(bytes.NewReader([]byte{}), hd)
-		res := helpers.Must(Handle(server, req))
+		res := helpers.Must(Handle(context.Background(), server, req))
 		require.Equal(t, res.Status(), http.StatusUnsupportedMediaType)
 	})
 
@@ -392,7 +393,7 @@ func TestHandle(t *testing.T) {
 		hd.Set("Accept", "not/acceptable")
 
 		req := thttp.NewHTTPRequest(bytes.NewReader([]byte{}), hd)
-		res := helpers.Must(Handle(server, req))
+		res := helpers.Must(Handle(context.Background(), server, req))
 		require.Equal(t, res.Status(), http.StatusNotAcceptable)
 	})
 
@@ -405,7 +406,7 @@ func TestHandle(t *testing.T) {
 
 		// request with invalid payload
 		req := thttp.NewHTTPRequest(bytes.NewReader([]byte{}), hd)
-		res := helpers.Must(Handle(server, req))
+		res := helpers.Must(Handle(context.Background(), server, req))
 		require.Equal(t, res.Status(), http.StatusBadRequest)
 	})
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -141,7 +141,7 @@ func TestExecute(t *testing.T) {
 		inv, err := invocation.Invoke(fixtures.Service, fixtures.Service, cap)
 		require.NoError(t, err)
 
-		resp, err := client.Execute(helpers.TestContext(t), []invocation.Invocation{inv}, conn)
+		resp, err := client.Execute(t.Context(), []invocation.Invocation{inv}, conn)
 		require.NoError(t, err)
 
 		// get the receipt link for the invocation from the response
@@ -197,7 +197,7 @@ func TestExecute(t *testing.T) {
 		inv, err := invocation.Invoke(fixtures.Alice, fixtures.Service, cap, delegation.WithProof(prfs...))
 		require.NoError(t, err)
 
-		resp, err := client.Execute(helpers.TestContext(t), []invocation.Invocation{inv}, conn)
+		resp, err := client.Execute(t.Context(), []invocation.Invocation{inv}, conn)
 		require.NoError(t, err)
 
 		// get the receipt link for the invocation from the response
@@ -231,7 +231,7 @@ func TestExecute(t *testing.T) {
 		)
 
 		invs := []invocation.Invocation{helpers.Must(invocation.Invoke(fixtures.Alice, fixtures.Service, capability))}
-		resp := helpers.Must(client.Execute(helpers.TestContext(t), invs, conn))
+		resp := helpers.Must(client.Execute(t.Context(), invs, conn))
 		rcptlnk, ok := resp.Get(invs[0].Link())
 		require.True(t, ok, "missing receipt for invocation: %s", invs[0].Link())
 
@@ -269,7 +269,7 @@ func TestExecute(t *testing.T) {
 		rt := cidlink.Link{Cid: cid.MustParse("bafkreiem4twkqzsq2aj4shbycd4yvoj2cx72vezicletlhi7dijjciqpui")}
 		cap := uploadadd.New(fixtures.Alice.DID().String(), uploadAddCaveats{Root: rt})
 		invs := []invocation.Invocation{helpers.Must(invocation.Invoke(fixtures.Alice, fixtures.Service, cap))}
-		resp := helpers.Must(client.Execute(helpers.TestContext(t), invs, conn))
+		resp := helpers.Must(client.Execute(t.Context(), invs, conn))
 		rcptlnk, ok := resp.Get(invs[0].Link())
 		require.True(t, ok, "missing receipt for invocation: %s", invs[0].Link())
 
@@ -310,7 +310,7 @@ func TestExecute(t *testing.T) {
 		// invocation audience different from the service
 		invs := []invocation.Invocation{helpers.Must(invocation.Invoke(fixtures.Alice, fixtures.Bob, cap))}
 
-		resp, err := client.Execute(helpers.TestContext(t), invs, conn)
+		resp, err := client.Execute(t.Context(), invs, conn)
 		require.NoError(t, err)
 
 		rcptlnk, ok := resp.Get(invs[0].Link())
@@ -353,7 +353,7 @@ func TestExecute(t *testing.T) {
 		// invocation audience different from the service, but an accepted alternative audience
 		invs := []invocation.Invocation{helpers.Must(invocation.Invoke(fixtures.Alice, fixtures.Bob, cap))}
 
-		resp, err := client.Execute(helpers.TestContext(t), invs, conn)
+		resp, err := client.Execute(t.Context(), invs, conn)
 		require.NoError(t, err)
 
 		rcptlnk, ok := resp.Get(invs[0].Link())
@@ -381,7 +381,7 @@ func TestHandle(t *testing.T) {
 		hd.Set("Accept", response.ContentType)
 
 		req := thttp.NewHTTPRequest(bytes.NewReader([]byte{}), hd)
-		res := helpers.Must(Handle(helpers.TestContext(t), server, req))
+		res := helpers.Must(Handle(t.Context(), server, req))
 		require.Equal(t, res.Status(), http.StatusUnsupportedMediaType)
 	})
 
@@ -393,7 +393,7 @@ func TestHandle(t *testing.T) {
 		hd.Set("Accept", "not/acceptable")
 
 		req := thttp.NewHTTPRequest(bytes.NewReader([]byte{}), hd)
-		res := helpers.Must(Handle(helpers.TestContext(t), server, req))
+		res := helpers.Must(Handle(t.Context(), server, req))
 		require.Equal(t, res.Status(), http.StatusNotAcceptable)
 	})
 
@@ -406,7 +406,7 @@ func TestHandle(t *testing.T) {
 
 		// request with invalid payload
 		req := thttp.NewHTTPRequest(bytes.NewReader([]byte{}), hd)
-		res := helpers.Must(Handle(helpers.TestContext(t), server, req))
+		res := helpers.Must(Handle(t.Context(), server, req))
 		require.Equal(t, res.Status(), http.StatusBadRequest)
 	})
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -141,7 +141,7 @@ func TestExecute(t *testing.T) {
 		inv, err := invocation.Invoke(fixtures.Service, fixtures.Service, cap)
 		require.NoError(t, err)
 
-		resp, err := client.Execute(context.Background(), []invocation.Invocation{inv}, conn)
+		resp, err := client.Execute(helpers.TestContext(t), []invocation.Invocation{inv}, conn)
 		require.NoError(t, err)
 
 		// get the receipt link for the invocation from the response
@@ -197,7 +197,7 @@ func TestExecute(t *testing.T) {
 		inv, err := invocation.Invoke(fixtures.Alice, fixtures.Service, cap, delegation.WithProof(prfs...))
 		require.NoError(t, err)
 
-		resp, err := client.Execute(context.Background(), []invocation.Invocation{inv}, conn)
+		resp, err := client.Execute(helpers.TestContext(t), []invocation.Invocation{inv}, conn)
 		require.NoError(t, err)
 
 		// get the receipt link for the invocation from the response
@@ -231,7 +231,7 @@ func TestExecute(t *testing.T) {
 		)
 
 		invs := []invocation.Invocation{helpers.Must(invocation.Invoke(fixtures.Alice, fixtures.Service, capability))}
-		resp := helpers.Must(client.Execute(context.Background(), invs, conn))
+		resp := helpers.Must(client.Execute(helpers.TestContext(t), invs, conn))
 		rcptlnk, ok := resp.Get(invs[0].Link())
 		require.True(t, ok, "missing receipt for invocation: %s", invs[0].Link())
 
@@ -269,7 +269,7 @@ func TestExecute(t *testing.T) {
 		rt := cidlink.Link{Cid: cid.MustParse("bafkreiem4twkqzsq2aj4shbycd4yvoj2cx72vezicletlhi7dijjciqpui")}
 		cap := uploadadd.New(fixtures.Alice.DID().String(), uploadAddCaveats{Root: rt})
 		invs := []invocation.Invocation{helpers.Must(invocation.Invoke(fixtures.Alice, fixtures.Service, cap))}
-		resp := helpers.Must(client.Execute(context.Background(), invs, conn))
+		resp := helpers.Must(client.Execute(helpers.TestContext(t), invs, conn))
 		rcptlnk, ok := resp.Get(invs[0].Link())
 		require.True(t, ok, "missing receipt for invocation: %s", invs[0].Link())
 
@@ -310,7 +310,7 @@ func TestExecute(t *testing.T) {
 		// invocation audience different from the service
 		invs := []invocation.Invocation{helpers.Must(invocation.Invoke(fixtures.Alice, fixtures.Bob, cap))}
 
-		resp, err := client.Execute(context.Background(), invs, conn)
+		resp, err := client.Execute(helpers.TestContext(t), invs, conn)
 		require.NoError(t, err)
 
 		rcptlnk, ok := resp.Get(invs[0].Link())
@@ -353,7 +353,7 @@ func TestExecute(t *testing.T) {
 		// invocation audience different from the service, but an accepted alternative audience
 		invs := []invocation.Invocation{helpers.Must(invocation.Invoke(fixtures.Alice, fixtures.Bob, cap))}
 
-		resp, err := client.Execute(context.Background(), invs, conn)
+		resp, err := client.Execute(helpers.TestContext(t), invs, conn)
 		require.NoError(t, err)
 
 		rcptlnk, ok := resp.Get(invs[0].Link())
@@ -381,7 +381,7 @@ func TestHandle(t *testing.T) {
 		hd.Set("Accept", response.ContentType)
 
 		req := thttp.NewHTTPRequest(bytes.NewReader([]byte{}), hd)
-		res := helpers.Must(Handle(context.Background(), server, req))
+		res := helpers.Must(Handle(helpers.TestContext(t), server, req))
 		require.Equal(t, res.Status(), http.StatusUnsupportedMediaType)
 	})
 
@@ -393,7 +393,7 @@ func TestHandle(t *testing.T) {
 		hd.Set("Accept", "not/acceptable")
 
 		req := thttp.NewHTTPRequest(bytes.NewReader([]byte{}), hd)
-		res := helpers.Must(Handle(context.Background(), server, req))
+		res := helpers.Must(Handle(helpers.TestContext(t), server, req))
 		require.Equal(t, res.Status(), http.StatusNotAcceptable)
 	})
 
@@ -406,7 +406,7 @@ func TestHandle(t *testing.T) {
 
 		// request with invalid payload
 		req := thttp.NewHTTPRequest(bytes.NewReader([]byte{}), hd)
-		res := helpers.Must(Handle(context.Background(), server, req))
+		res := helpers.Must(Handle(helpers.TestContext(t), server, req))
 		require.Equal(t, res.Status(), http.StatusBadRequest)
 	})
 }

--- a/testing/helpers/helpers.go
+++ b/testing/helpers/helpers.go
@@ -1,7 +1,9 @@
 package helpers
 
 import (
+	"context"
 	crand "crypto/rand"
+	"testing"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime/datamodel"
@@ -33,4 +35,13 @@ func RandomCID() datamodel.Link {
 		MhLength: -1,
 	}.Sum(bytes)
 	return cidlink.Link{Cid: c}
+}
+
+// TestContext returns the `t.Context()` if available (Go 1.24+), or a
+// background context on older versions of Go.
+func TestContext(t *testing.T) context.Context {
+	if tCtx, ok := any(t).(interface{ Context() context.Context }); ok {
+		return tCtx.Context()
+	}
+	return context.Background()
 }

--- a/testing/helpers/helpers.go
+++ b/testing/helpers/helpers.go
@@ -1,9 +1,7 @@
 package helpers
 
 import (
-	"context"
 	crand "crypto/rand"
-	"testing"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime/datamodel"
@@ -35,13 +33,4 @@ func RandomCID() datamodel.Link {
 		MhLength: -1,
 	}.Sum(bytes)
 	return cidlink.Link{Cid: c}
-}
-
-// TestContext returns the `t.Context()` if available (Go 1.24+), or a
-// background context on older versions of Go.
-func TestContext(t *testing.T) context.Context {
-	if tCtx, ok := any(t).(interface{ Context() context.Context }); ok {
-		return tCtx.Context()
-	}
-	return context.Background()
 }

--- a/transport/car/request/request.go
+++ b/transport/car/request/request.go
@@ -26,11 +26,11 @@ func Encode(message message.AgentMessage) (transport.HTTPRequest, error) {
 func Decode(req transport.HTTPRequest) (message.AgentMessage, error) {
 	roots, blocks, err := car.Decode(req.Body())
 	if err != nil {
-		return nil, fmt.Errorf("decoding CAR: %s", err)
+		return nil, fmt.Errorf("decoding CAR: %w", err)
 	}
 	bstore, err := blockstore.NewBlockReader(blockstore.WithBlocksIterator(blocks))
 	if err != nil {
-		return nil, fmt.Errorf("creating blockstore: %s", err)
+		return nil, fmt.Errorf("creating blockstore: %w", err)
 	}
 	return message.NewMessage(roots, bstore)
 }

--- a/transport/car/response/response.go
+++ b/transport/car/response/response.go
@@ -24,11 +24,11 @@ func Encode(msg message.AgentMessage) (transport.HTTPResponse, error) {
 func Decode(response transport.HTTPResponse) (message.AgentMessage, error) {
 	roots, blocks, err := car.Decode(response.Body())
 	if err != nil {
-		return nil, fmt.Errorf("decoding CAR: %s", err)
+		return nil, fmt.Errorf("decoding CAR: %w", err)
 	}
 	bstore, err := blockstore.NewBlockReader(blockstore.WithBlocksIterator(blocks))
 	if err != nil {
-		return nil, fmt.Errorf("creating blockstore: %s", err)
+		return nil, fmt.Errorf("creating blockstore: %w", err)
 	}
 	return message.NewMessage(roots, bstore)
 }

--- a/transport/channel.go
+++ b/transport/channel.go
@@ -1,5 +1,7 @@
 package transport
 
+import "context"
+
 type Channel interface {
-	Request(request HTTPRequest) (HTTPResponse, error)
+	Request(ctx context.Context, request HTTPRequest) (HTTPResponse, error)
 }

--- a/transport/http/channel.go
+++ b/transport/http/channel.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -13,16 +14,16 @@ type channel struct {
 	client *http.Client
 }
 
-func (c *channel) Request(req transport.HTTPRequest) (transport.HTTPResponse, error) {
-	hr, err := http.NewRequest("POST", c.url.String(), req.Body())
+func (c *channel) Request(ctx context.Context, req transport.HTTPRequest) (transport.HTTPResponse, error) {
+	hr, err := http.NewRequestWithContext(ctx, "POST", c.url.String(), req.Body())
 	if err != nil {
-		return nil, fmt.Errorf("creating HTTP request: %s", err)
+		return nil, fmt.Errorf("creating HTTP request: %w", err)
 	}
 
 	hr.Header = req.Headers()
 	res, err := c.client.Do(hr)
 	if err != nil {
-		return nil, fmt.Errorf("doing HTTP request: %s", err)
+		return nil, fmt.Errorf("doing HTTP request: %w", err)
 	}
 	if res.StatusCode != http.StatusOK {
 		return nil, NewHTTPError(fmt.Sprintf("HTTP Request failed. %s %s → %d", hr.Method, c.url.String(), res.StatusCode), res.StatusCode, res.Header)

--- a/ucan/datamodel/header/header.go
+++ b/ucan/datamodel/header/header.go
@@ -23,7 +23,7 @@ func mustLoadSchema() *schema.TypeSystem {
 		ts, err = ipld.LoadSchemaBytes(headersch)
 	})
 	if err != nil {
-		panic(fmt.Errorf("failed to load IPLD schema: %s", err))
+		panic(fmt.Errorf("failed to load IPLD schema: %w", err))
 	}
 	return ts
 }

--- a/ucan/datamodel/payload/payload.go
+++ b/ucan/datamodel/payload/payload.go
@@ -24,7 +24,7 @@ func mustLoadSchema() *schema.TypeSystem {
 		ts, err = ipld.LoadSchemaBytes(payloadsch)
 	})
 	if err != nil {
-		panic(fmt.Errorf("failed to load IPLD schema: %s", err))
+		panic(fmt.Errorf("failed to load IPLD schema: %w", err))
 	}
 	return ts
 }

--- a/ucan/datamodel/ucan/ucan.go
+++ b/ucan/datamodel/ucan/ucan.go
@@ -24,7 +24,7 @@ func mustLoadSchema() *schema.TypeSystem {
 		ts, err = ipld.LoadSchemaBytes(ucansch)
 	})
 	if err != nil {
-		panic(fmt.Errorf("failed to load IPLD schema: %s", err))
+		panic(fmt.Errorf("failed to load IPLD schema: %w", err))
 	}
 	return ts
 }

--- a/ucan/formatter/formatter.go
+++ b/ucan/formatter/formatter.go
@@ -18,7 +18,7 @@ func FormatSignPayload(payload pdm.PayloadModel, version string, algorithm strin
 	}
 	pld, err := FormatPayload(payload)
 	if err != nil {
-		return "", fmt.Errorf("formatting payload: %s", err)
+		return "", fmt.Errorf("formatting payload: %w", err)
 	}
 	return fmt.Sprintf("%s.%s", hdr, pld), nil
 }
@@ -31,7 +31,7 @@ func FormatHeader(version string, algorithm string) (string, error) {
 	}
 	bytes, err := ipld.Marshal(dagjson.Encode, &header, hdm.Type())
 	if err != nil {
-		return "", fmt.Errorf("dag-json encoding header: %s", err)
+		return "", fmt.Errorf("dag-json encoding header: %w", err)
 	}
 	return base64.RawURLEncoding.EncodeToString(bytes), nil
 }
@@ -39,7 +39,7 @@ func FormatHeader(version string, algorithm string) (string, error) {
 func FormatPayload(payload pdm.PayloadModel) (string, error) {
 	bytes, err := ipld.Marshal(dagjson.Encode, &payload, pdm.Type())
 	if err != nil {
-		return "", fmt.Errorf("dag-json encoding payload: %s", err)
+		return "", fmt.Errorf("dag-json encoding payload: %w", err)
 	}
 	return base64.RawURLEncoding.EncodeToString(bytes), nil
 }

--- a/ucan/lib.go
+++ b/ucan/lib.go
@@ -115,7 +115,7 @@ func Issue[C CaveatBuilder](issuer Signer, audience Principal, capabilities []Ca
 	for _, cap := range capabilities {
 		nb, err := cap.Nb().ToIPLD()
 		if err != nil {
-			return nil, fmt.Errorf("building caveats: %s", err)
+			return nil, fmt.Errorf("building caveats: %w", err)
 		}
 		m := udm.CapabilityModel{
 			With: cap.With(),
@@ -134,7 +134,7 @@ func Issue[C CaveatBuilder](issuer Signer, audience Principal, capabilities []Ca
 	for _, f := range cfg.fct {
 		vals, err := f.ToIPLD()
 		if err != nil {
-			return nil, fmt.Errorf("building fact: %s", err)
+			return nil, fmt.Errorf("building fact: %w", err)
 		}
 		var keys []string
 		for k := range vals {
@@ -162,7 +162,7 @@ func Issue[C CaveatBuilder](issuer Signer, audience Principal, capabilities []Ca
 	}
 	bytes, err := encodeSignaturePayload(payload, version, issuer.SignatureAlgorithm())
 	if err != nil {
-		return nil, fmt.Errorf("encoding signature payload: %s", err)
+		return nil, fmt.Errorf("encoding signature payload: %w", err)
 	}
 
 	model := udm.UCANModel{

--- a/validator/datamodel/attestation.go
+++ b/validator/datamodel/attestation.go
@@ -16,7 +16,7 @@ var attestationTypeSystem *schema.TypeSystem
 func init() {
 	ts, err := ipld.LoadSchemaBytes(attestationsch)
 	if err != nil {
-		panic(fmt.Errorf("failed to load IPLD schema: %s", err))
+		panic(fmt.Errorf("failed to load IPLD schema: %w", err))
 	}
 	attestationTypeSystem = ts
 }

--- a/validator/datamodel/errors.go
+++ b/validator/datamodel/errors.go
@@ -19,7 +19,7 @@ var (
 func init() {
 	ts, err := ipld.LoadSchemaBytes(errorsch)
 	if err != nil {
-		panic(fmt.Errorf("failed to load IPLD schema: %s", err))
+		panic(fmt.Errorf("failed to load IPLD schema: %w", err))
 	}
 	errorTypeSystem = ts
 }

--- a/validator/lib_test.go
+++ b/validator/lib_test.go
@@ -107,7 +107,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.NoError(t, x)
 			require.Equal(t, storeAdd.Can(), a.Capability().Can())
 			require.Equal(t, fixtures.Alice.DID().String(), a.Capability().With())
@@ -143,7 +143,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.NoError(t, x)
 			require.Equal(t, storeAdd.Can(), a.Capability().Can())
 			require.Equal(t, fixtures.Alice.DID().String(), a.Capability().With())
@@ -188,7 +188,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.NoError(t, x)
 			require.Equal(t, storeAdd.Can(), a.Capability().Can())
 			require.Equal(t, fixtures.Alice.DID().String(), a.Capability().With())
@@ -239,7 +239,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.NoError(t, x)
 			require.Equal(t, storeAdd.Can(), a.Capability().Can())
 			require.Equal(t, fixtures.Alice.DID().String(), a.Capability().With())
@@ -275,7 +275,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -307,7 +307,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -339,7 +339,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -372,7 +372,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -406,7 +406,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -449,7 +449,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -493,7 +493,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -556,7 +556,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -599,7 +599,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -643,7 +643,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -686,7 +686,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -729,7 +729,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -772,7 +772,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -825,7 +825,7 @@ func TestAccess(t *testing.T) {
 			)
 
 			cstr := fmt.Sprintf(`{"can":"%s","with":"%s","nb":{"Link":{"/":"%s"},"Origin":null}}`, storeAdd.Can(), fixtures.Service.DID(), testLink)
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -872,7 +872,7 @@ func TestAccess(t *testing.T) {
 			)
 
 			cstr := fmt.Sprintf(`{"can":"%s","with":"%s","nb":{"Link":{"/":"%s"},"Origin":null}}`, storeAdd.Can(), fixtures.Alice.DID(), testLink)
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -918,7 +918,7 @@ func TestAccess(t *testing.T) {
 			)
 
 			cstr := fmt.Sprintf(`{"can":"%s","with":"%s","nb":{"Link":{"/":"%s"},"Origin":null}}`, storeAdd.Can(), space.DID(), testLink)
-			a, x := Access(context.Background(), inv, vctx)
+			a, x := Access(helpers.TestContext(t), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -954,7 +954,7 @@ func TestClaim(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Claim(context.Background(), storeAdd, []delegation.Proof{delegation.FromLink(dlg.Link())}, vctx)
+		a, x := Claim(helpers.TestContext(t), storeAdd, []delegation.Proof{delegation.FromLink(dlg.Link())}, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 		require.Equal(t, x.Name(), "Unauthorized")
@@ -994,7 +994,7 @@ func TestClaim(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Claim(context.Background(), storeAdd, []delegation.Proof{delegation.FromDelegation(dlg)}, vctx)
+		a, x := Claim(helpers.TestContext(t), storeAdd, []delegation.Proof{delegation.FromDelegation(dlg)}, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 		require.Equal(t, x.Name(), "Unauthorized")

--- a/validator/lib_test.go
+++ b/validator/lib_test.go
@@ -1,6 +1,7 @@
 package validator
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -80,7 +81,7 @@ var storeAdd = NewCapability(
 )
 
 var testLink = cidlink.Link{Cid: cid.MustParse("bafkqaaa")}
-var validateAuthOk = func(auth Authorization[any]) Revoked { return nil }
+var validateAuthOk = func(ctx context.Context, auth Authorization[any]) Revoked { return nil }
 var parseEdPrincipal = func(str string) (principal.Verifier, error) {
 	return verifier.Parse(str)
 }
@@ -96,7 +97,7 @@ func TestAccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
@@ -106,7 +107,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.NoError(t, x)
 			require.Equal(t, storeAdd.Can(), a.Capability().Can())
 			require.Equal(t, fixtures.Alice.DID().String(), a.Capability().With())
@@ -132,7 +133,7 @@ func TestAccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
@@ -142,7 +143,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.NoError(t, x)
 			require.Equal(t, storeAdd.Can(), a.Capability().Can())
 			require.Equal(t, fixtures.Alice.DID().String(), a.Capability().With())
@@ -177,7 +178,7 @@ func TestAccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
@@ -187,7 +188,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.NoError(t, x)
 			require.Equal(t, storeAdd.Can(), a.Capability().Can())
 			require.Equal(t, fixtures.Alice.DID().String(), a.Capability().With())
@@ -223,12 +224,12 @@ func TestAccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
 				validateAuthOk,
-				func(p ucan.Link) (delegation.Delegation, UnavailableProof) {
+				func(ctx context.Context, p ucan.Link) (delegation.Delegation, UnavailableProof) {
 					if p == dlg.Link() {
 						return dlg, nil
 					}
@@ -238,7 +239,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.NoError(t, x)
 			require.Equal(t, storeAdd.Can(), a.Capability().Can())
 			require.Equal(t, fixtures.Alice.DID().String(), a.Capability().With())
@@ -264,7 +265,7 @@ func TestAccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
@@ -274,7 +275,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -296,7 +297,7 @@ func TestAccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
@@ -306,7 +307,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -328,7 +329,7 @@ func TestAccess(t *testing.T) {
 
 			inv.Data().Model().S = fixtures.Bob.Sign(inv.Root().Bytes()).Bytes()
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
@@ -338,7 +339,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -361,7 +362,7 @@ func TestAccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
@@ -371,7 +372,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -395,7 +396,7 @@ func TestAccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
@@ -405,7 +406,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -438,7 +439,7 @@ func TestAccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
@@ -448,7 +449,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -482,7 +483,7 @@ func TestAccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
@@ -492,7 +493,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -545,7 +546,7 @@ func TestAccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
@@ -555,7 +556,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -588,7 +589,7 @@ func TestAccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
@@ -598,7 +599,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -632,7 +633,7 @@ func TestAccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
@@ -642,7 +643,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -675,7 +676,7 @@ func TestAccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
@@ -685,7 +686,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -718,7 +719,7 @@ func TestAccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
@@ -728,7 +729,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -761,7 +762,7 @@ func TestAccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
@@ -771,7 +772,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -813,7 +814,7 @@ func TestAccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
@@ -824,7 +825,7 @@ func TestAccess(t *testing.T) {
 			)
 
 			cstr := fmt.Sprintf(`{"can":"%s","with":"%s","nb":{"Link":{"/":"%s"},"Origin":null}}`, storeAdd.Can(), fixtures.Service.DID(), testLink)
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -860,7 +861,7 @@ func TestAccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
@@ -871,7 +872,7 @@ func TestAccess(t *testing.T) {
 			)
 
 			cstr := fmt.Sprintf(`{"can":"%s","with":"%s","nb":{"Link":{"/":"%s"},"Origin":null}}`, storeAdd.Can(), fixtures.Alice.DID(), testLink)
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -906,7 +907,7 @@ func TestAccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			context := NewValidationContext(
+			vctx := NewValidationContext(
 				fixtures.Service.Verifier(),
 				storeAdd,
 				IsSelfIssued,
@@ -917,7 +918,7 @@ func TestAccess(t *testing.T) {
 			)
 
 			cstr := fmt.Sprintf(`{"can":"%s","with":"%s","nb":{"Link":{"/":"%s"},"Origin":null}}`, storeAdd.Can(), space.DID(), testLink)
-			a, x := Access(inv, context)
+			a, x := Access(context.Background(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -943,7 +944,7 @@ func TestClaim(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		context := NewValidationContext(
+		vctx := NewValidationContext(
 			fixtures.Service.Verifier(),
 			storeAdd,
 			IsSelfIssued,
@@ -953,7 +954,7 @@ func TestClaim(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Claim(storeAdd, []delegation.Proof{delegation.FromLink(dlg.Link())}, context)
+		a, x := Claim(context.Background(), storeAdd, []delegation.Proof{delegation.FromLink(dlg.Link())}, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 		require.Equal(t, x.Name(), "Unauthorized")
@@ -983,7 +984,7 @@ func TestClaim(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		context := NewValidationContext(
+		vctx := NewValidationContext(
 			new.Verifier(),
 			storeAdd,
 			IsSelfIssued,
@@ -993,7 +994,7 @@ func TestClaim(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Claim(storeAdd, []delegation.Proof{delegation.FromDelegation(dlg)}, context)
+		a, x := Claim(context.Background(), storeAdd, []delegation.Proof{delegation.FromDelegation(dlg)}, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 		require.Equal(t, x.Name(), "Unauthorized")

--- a/validator/lib_test.go
+++ b/validator/lib_test.go
@@ -107,7 +107,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.NoError(t, x)
 			require.Equal(t, storeAdd.Can(), a.Capability().Can())
 			require.Equal(t, fixtures.Alice.DID().String(), a.Capability().With())
@@ -143,7 +143,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.NoError(t, x)
 			require.Equal(t, storeAdd.Can(), a.Capability().Can())
 			require.Equal(t, fixtures.Alice.DID().String(), a.Capability().With())
@@ -188,7 +188,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.NoError(t, x)
 			require.Equal(t, storeAdd.Can(), a.Capability().Can())
 			require.Equal(t, fixtures.Alice.DID().String(), a.Capability().With())
@@ -239,7 +239,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.NoError(t, x)
 			require.Equal(t, storeAdd.Can(), a.Capability().Can())
 			require.Equal(t, fixtures.Alice.DID().String(), a.Capability().With())
@@ -275,7 +275,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -307,7 +307,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -339,7 +339,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -372,7 +372,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -406,7 +406,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -449,7 +449,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -493,7 +493,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -556,7 +556,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -599,7 +599,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -643,7 +643,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -686,7 +686,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -729,7 +729,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -772,7 +772,7 @@ func TestAccess(t *testing.T) {
 				FailDIDKeyResolution,
 			)
 
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -825,7 +825,7 @@ func TestAccess(t *testing.T) {
 			)
 
 			cstr := fmt.Sprintf(`{"can":"%s","with":"%s","nb":{"Link":{"/":"%s"},"Origin":null}}`, storeAdd.Can(), fixtures.Service.DID(), testLink)
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -872,7 +872,7 @@ func TestAccess(t *testing.T) {
 			)
 
 			cstr := fmt.Sprintf(`{"can":"%s","with":"%s","nb":{"Link":{"/":"%s"},"Origin":null}}`, storeAdd.Can(), fixtures.Alice.DID(), testLink)
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -918,7 +918,7 @@ func TestAccess(t *testing.T) {
 			)
 
 			cstr := fmt.Sprintf(`{"can":"%s","with":"%s","nb":{"Link":{"/":"%s"},"Origin":null}}`, storeAdd.Can(), space.DID(), testLink)
-			a, x := Access(helpers.TestContext(t), inv, vctx)
+			a, x := Access(t.Context(), inv, vctx)
 			require.Nil(t, a)
 			require.Error(t, x)
 			require.Equal(t, x.Name(), "Unauthorized")
@@ -954,7 +954,7 @@ func TestClaim(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Claim(helpers.TestContext(t), storeAdd, []delegation.Proof{delegation.FromLink(dlg.Link())}, vctx)
+		a, x := Claim(t.Context(), storeAdd, []delegation.Proof{delegation.FromLink(dlg.Link())}, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 		require.Equal(t, x.Name(), "Unauthorized")
@@ -994,7 +994,7 @@ func TestClaim(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Claim(helpers.TestContext(t), storeAdd, []delegation.Proof{delegation.FromDelegation(dlg)}, vctx)
+		a, x := Claim(t.Context(), storeAdd, []delegation.Proof{delegation.FromDelegation(dlg)}, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 		require.Equal(t, x.Name(), "Unauthorized")

--- a/validator/session_test.go
+++ b/validator/session_test.go
@@ -1,6 +1,7 @@
 package validator
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"strings"
@@ -127,7 +128,7 @@ func TestSession(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		context := NewValidationContext(
+		vctx := NewValidationContext(
 			service.Verifier(),
 			debugEcho,
 			IsSelfIssued,
@@ -137,7 +138,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(inv, context)
+		a, x := Access(context.Background(), inv, vctx)
 		require.NoError(t, x)
 		require.Equal(t, debugEcho.Can(), a.Capability().Can())
 		require.Equal(t, account.DID().String(), a.Capability().With())
@@ -191,24 +192,24 @@ func TestSession(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		context := NewValidationContext(
+		vctx := NewValidationContext(
 			service.Verifier(),
 			debugEcho,
 			IsSelfIssued,
 			validateAuthOk,
 			ProofUnavailable,
 			parseEdPrincipal,
-			func(d did.DID) (did.DID, UnresolvedDID) {
+			func(ctx context.Context, d did.DID) (did.DID, UnresolvedDID) {
 				if d == othersvc.DID() {
 					return othersvc.(signer.WrappedSigner).Unwrap().DID(), nil
 				}
 
-				return FailDIDKeyResolution(d)
+				return FailDIDKeyResolution(ctx, d)
 			},
 			auth,
 		)
 
-		a, x := Access(inv, context)
+		a, x := Access(context.Background(), inv, vctx)
 		require.NoError(t, x)
 		require.Equal(t, debugEcho.Can(), a.Capability().Can())
 		require.Equal(t, account.DID().String(), a.Capability().With())
@@ -286,7 +287,7 @@ func TestSession(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		context := NewValidationContext(
+		vctx := NewValidationContext(
 			service.Verifier(),
 			debugEcho,
 			IsSelfIssued,
@@ -296,7 +297,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(inv, context)
+		a, x := Access(context.Background(), inv, vctx)
 		require.NoError(t, x)
 		require.Equal(t, debugEcho.Can(), a.Capability().Can())
 		require.Equal(t, account.DID().String(), a.Capability().With())
@@ -316,7 +317,7 @@ func TestSession(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		context := NewValidationContext(
+		vctx := NewValidationContext(
 			service.Verifier(),
 			debugEcho,
 			IsSelfIssued,
@@ -326,7 +327,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(inv, context)
+		a, x := Access(context.Background(), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 		require.Equal(t, x.Name(), "Unauthorized")
@@ -361,7 +362,7 @@ func TestSession(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		context := NewValidationContext(
+		vctx := NewValidationContext(
 			service.Verifier(),
 			debugEcho,
 			IsSelfIssued,
@@ -371,7 +372,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(inv, context)
+		a, x := Access(context.Background(), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 		require.Equal(t, x.Name(), "Unauthorized")
@@ -429,7 +430,7 @@ func TestSession(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		context := NewValidationContext(
+		vctx := NewValidationContext(
 			service.Verifier(),
 			debugEcho,
 			IsSelfIssued,
@@ -439,7 +440,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(inv, context)
+		a, x := Access(context.Background(), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 		require.Equal(t, x.Name(), "Unauthorized")
@@ -485,23 +486,23 @@ func TestSession(t *testing.T) {
 		require.NoError(t, err)
 
 		// authority is service, but attestation was issued by othersvc
-		context := NewValidationContext(
+		vctx := NewValidationContext(
 			service.Verifier(),
 			debugEcho,
 			IsSelfIssued,
 			validateAuthOk,
 			ProofUnavailable,
 			parseEdPrincipal,
-			func(d did.DID) (did.DID, UnresolvedDID) {
+			func(ctx context.Context, d did.DID) (did.DID, UnresolvedDID) {
 				if d == othersvc.DID() {
 					return othersvc.(signer.WrappedSigner).Unwrap().DID(), nil
 				}
 
-				return FailDIDKeyResolution(d)
+				return FailDIDKeyResolution(ctx, d)
 			},
 		)
 
-		a, x := Access(inv, context)
+		a, x := Access(context.Background(), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 		require.Equal(t, x.Name(), "Unauthorized")
@@ -522,19 +523,19 @@ func TestSession(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		context := NewValidationContext(
+		vctx := NewValidationContext(
 			service.Verifier(),
 			debugEcho,
 			IsSelfIssued,
 			validateAuthOk,
 			ProofUnavailable,
 			parseEdPrincipal,
-			func(d did.DID) (did.DID, UnresolvedDID) {
+			func(ctx context.Context, d did.DID) (did.DID, UnresolvedDID) {
 				return fixtures.Alice.DID(), nil
 			},
 		)
 
-		a, x := Access(inv, context)
+		a, x := Access(context.Background(), inv, vctx)
 		require.NoError(t, x)
 		require.Equal(t, debugEcho.Can(), a.Capability().Can())
 		require.Equal(t, account.DID().String(), a.Capability().With())
@@ -577,7 +578,7 @@ func TestSession(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		context := NewValidationContext(
+		vctx := NewValidationContext(
 			service.Verifier(),
 			debugEcho,
 			IsSelfIssued,
@@ -587,7 +588,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(inv, context)
+		a, x := Access(context.Background(), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 	})
@@ -629,7 +630,7 @@ func TestSession(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		context := NewValidationContext(
+		vctx := NewValidationContext(
 			service.Verifier(),
 			debugEcho,
 			IsSelfIssued,
@@ -639,7 +640,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(inv, context)
+		a, x := Access(context.Background(), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 	})
@@ -667,7 +668,7 @@ func TestSession(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		context := NewValidationContext(
+		vctx := NewValidationContext(
 			service.Verifier(),
 			debugEcho,
 			IsSelfIssued,
@@ -677,7 +678,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(inv, context)
+		a, x := Access(context.Background(), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 	})
@@ -730,7 +731,7 @@ func TestSession(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		context := NewValidationContext(
+		vctx := NewValidationContext(
 			service.Verifier(),
 			debugEcho,
 			IsSelfIssued,
@@ -740,7 +741,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(inv, context)
+		a, x := Access(context.Background(), inv, vctx)
 		require.NotEmpty(t, a)
 		require.NoError(t, x)
 	})

--- a/validator/session_test.go
+++ b/validator/session_test.go
@@ -138,7 +138,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(context.Background(), inv, vctx)
+		a, x := Access(helpers.TestContext(t), inv, vctx)
 		require.NoError(t, x)
 		require.Equal(t, debugEcho.Can(), a.Capability().Can())
 		require.Equal(t, account.DID().String(), a.Capability().With())
@@ -209,7 +209,7 @@ func TestSession(t *testing.T) {
 			auth,
 		)
 
-		a, x := Access(context.Background(), inv, vctx)
+		a, x := Access(helpers.TestContext(t), inv, vctx)
 		require.NoError(t, x)
 		require.Equal(t, debugEcho.Can(), a.Capability().Can())
 		require.Equal(t, account.DID().String(), a.Capability().With())
@@ -297,7 +297,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(context.Background(), inv, vctx)
+		a, x := Access(helpers.TestContext(t), inv, vctx)
 		require.NoError(t, x)
 		require.Equal(t, debugEcho.Can(), a.Capability().Can())
 		require.Equal(t, account.DID().String(), a.Capability().With())
@@ -327,7 +327,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(context.Background(), inv, vctx)
+		a, x := Access(helpers.TestContext(t), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 		require.Equal(t, x.Name(), "Unauthorized")
@@ -372,7 +372,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(context.Background(), inv, vctx)
+		a, x := Access(helpers.TestContext(t), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 		require.Equal(t, x.Name(), "Unauthorized")
@@ -440,7 +440,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(context.Background(), inv, vctx)
+		a, x := Access(helpers.TestContext(t), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 		require.Equal(t, x.Name(), "Unauthorized")
@@ -502,7 +502,7 @@ func TestSession(t *testing.T) {
 			},
 		)
 
-		a, x := Access(context.Background(), inv, vctx)
+		a, x := Access(helpers.TestContext(t), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 		require.Equal(t, x.Name(), "Unauthorized")
@@ -535,7 +535,7 @@ func TestSession(t *testing.T) {
 			},
 		)
 
-		a, x := Access(context.Background(), inv, vctx)
+		a, x := Access(helpers.TestContext(t), inv, vctx)
 		require.NoError(t, x)
 		require.Equal(t, debugEcho.Can(), a.Capability().Can())
 		require.Equal(t, account.DID().String(), a.Capability().With())
@@ -588,7 +588,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(context.Background(), inv, vctx)
+		a, x := Access(helpers.TestContext(t), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 	})
@@ -640,7 +640,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(context.Background(), inv, vctx)
+		a, x := Access(helpers.TestContext(t), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 	})
@@ -678,7 +678,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(context.Background(), inv, vctx)
+		a, x := Access(helpers.TestContext(t), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 	})
@@ -741,7 +741,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(context.Background(), inv, vctx)
+		a, x := Access(helpers.TestContext(t), inv, vctx)
 		require.NotEmpty(t, a)
 		require.NoError(t, x)
 	})

--- a/validator/session_test.go
+++ b/validator/session_test.go
@@ -138,7 +138,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(helpers.TestContext(t), inv, vctx)
+		a, x := Access(t.Context(), inv, vctx)
 		require.NoError(t, x)
 		require.Equal(t, debugEcho.Can(), a.Capability().Can())
 		require.Equal(t, account.DID().String(), a.Capability().With())
@@ -209,7 +209,7 @@ func TestSession(t *testing.T) {
 			auth,
 		)
 
-		a, x := Access(helpers.TestContext(t), inv, vctx)
+		a, x := Access(t.Context(), inv, vctx)
 		require.NoError(t, x)
 		require.Equal(t, debugEcho.Can(), a.Capability().Can())
 		require.Equal(t, account.DID().String(), a.Capability().With())
@@ -297,7 +297,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(helpers.TestContext(t), inv, vctx)
+		a, x := Access(t.Context(), inv, vctx)
 		require.NoError(t, x)
 		require.Equal(t, debugEcho.Can(), a.Capability().Can())
 		require.Equal(t, account.DID().String(), a.Capability().With())
@@ -327,7 +327,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(helpers.TestContext(t), inv, vctx)
+		a, x := Access(t.Context(), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 		require.Equal(t, x.Name(), "Unauthorized")
@@ -372,7 +372,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(helpers.TestContext(t), inv, vctx)
+		a, x := Access(t.Context(), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 		require.Equal(t, x.Name(), "Unauthorized")
@@ -440,7 +440,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(helpers.TestContext(t), inv, vctx)
+		a, x := Access(t.Context(), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 		require.Equal(t, x.Name(), "Unauthorized")
@@ -502,7 +502,7 @@ func TestSession(t *testing.T) {
 			},
 		)
 
-		a, x := Access(helpers.TestContext(t), inv, vctx)
+		a, x := Access(t.Context(), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 		require.Equal(t, x.Name(), "Unauthorized")
@@ -535,7 +535,7 @@ func TestSession(t *testing.T) {
 			},
 		)
 
-		a, x := Access(helpers.TestContext(t), inv, vctx)
+		a, x := Access(t.Context(), inv, vctx)
 		require.NoError(t, x)
 		require.Equal(t, debugEcho.Can(), a.Capability().Can())
 		require.Equal(t, account.DID().String(), a.Capability().With())
@@ -588,7 +588,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(helpers.TestContext(t), inv, vctx)
+		a, x := Access(t.Context(), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 	})
@@ -640,7 +640,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(helpers.TestContext(t), inv, vctx)
+		a, x := Access(t.Context(), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 	})
@@ -678,7 +678,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(helpers.TestContext(t), inv, vctx)
+		a, x := Access(t.Context(), inv, vctx)
 		require.Nil(t, a)
 		require.Error(t, x)
 	})
@@ -741,7 +741,7 @@ func TestSession(t *testing.T) {
 			FailDIDKeyResolution,
 		)
 
-		a, x := Access(helpers.TestContext(t), inv, vctx)
+		a, x := Access(t.Context(), inv, vctx)
 		require.NotEmpty(t, a)
 		require.NoError(t, x)
 	})


### PR DESCRIPTION
resolves https://github.com/storacha/go-ucanto/issues/43

...also fixes a bunch of `%s` where we should be using `%w`.

BREAKING CHANGE: client and server now support context passing. Note that function signatures have changed to accommodate.