### PR TITLE
fix: access attached blocks after serde

### DIFF
--- a/core/delegation/delegation.go
+++ b/core/delegation/delegation.go
@@ -34,7 +34,7 @@ type Delegation interface {
 	Link() ucan.Link
 	// Archive writes the delegation to a Content Addressed aRchive (CAR).
 	Archive() io.Reader
-	// Export ONLY the blocks that comprise the delegation and it's proofs as well
+	// Export ONLY the blocks for the delegation and it's proofs, as well
 	// as blocks attached using Attach.
 	//
 	// Note: this differs from calling Blocks - which simply iterates over all


### PR DESCRIPTION
https://github.com/storacha/go-ucanto/pull/45 fixed a bug but also introduced a bug that prevents "attached" blocks from being accessed after a delegation is serialized to a CAR file and deserialized back to a Delegation (i.e. an invocation).

We attach blocks for example when a storage node invokes `claim/cache` on the indexer. The attached block is the claim.

When you serialize a delegation to a CAR, the "attached" blocks are included in the CAR but the fact that they are attached is lost. When deserializing you just create a delegation with a blockstore that contains all the blocks in the CAR - you don't know which ones were "attached".

The `Blocks()` method was changed in https://github.com/storacha/go-ucanto/pull/45 to "export" the delegation instead of just iterate over all the blocks. This meant that invocation handlers were no longer able to access the attached blocks 🙈

Changes:

* Revert change to `Blocks()` - this now iterates over all blocks as it did before.
* Add method `Export()` - which iterates ONLY the blocks for the delegation (and it's proofs), regardless of what other blocks are in the blockstore.

Note: this is now fully consistent with the JS implementation.