### PR TITLE
feat: custom failures

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -14,12 +14,20 @@ import (
 	"github.com/storacha/go-ucanto/validator"
 )
 
-type HandlerFunc[C any, O ipld.Builder, X failure.IPLDBuilderFailure] func(ctx context.Context, capability ucan.Capability[C], invocation invocation.Invocation, context InvocationContext) (result result.Result[O, X], fx fx.Effects, err error)
+type HandlerFunc[C any, O ipld.Builder, X failure.IPLDBuilderFailure] func(
+	ctx context.Context,
+	capability ucan.Capability[C],
+	invocation invocation.Invocation,
+	context InvocationContext,
+) (result result.Result[O, X], fx fx.Effects, err error)
 
 // Provide is used to define given capability provider. It decorates the passed
 // handler and takes care of UCAN validation. It only calls the handler
 // when validation succeeds.
-func Provide[C any, O ipld.Builder, X failure.IPLDBuilderFailure](capability validator.CapabilityParser[C], handler HandlerFunc[C, O, X]) ServiceMethod[O, failure.IPLDBuilderFailure] {
+func Provide[C any, O ipld.Builder, X failure.IPLDBuilderFailure](
+	capability validator.CapabilityParser[C],
+	handler HandlerFunc[C, O, X],
+) ServiceMethod[O, failure.IPLDBuilderFailure] {
 	return func(ctx context.Context, invocation invocation.Invocation, ictx InvocationContext) (transaction.Transaction[O, failure.IPLDBuilderFailure], error) {
 		vctx := validator.NewValidationContext(
 			ictx.ID().Verifier(),

--- a/server/server.go
+++ b/server/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/storacha/go-ucanto/core/message"
 	"github.com/storacha/go-ucanto/core/receipt"
 	"github.com/storacha/go-ucanto/core/result"
+	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/did"
 	"github.com/storacha/go-ucanto/principal"
 	"github.com/storacha/go-ucanto/principal/ed25519/verifier"
@@ -44,11 +45,11 @@ type InvocationContext interface {
 }
 
 // ServiceMethod is an invocation handler.
-type ServiceMethod[O ipld.Builder] func(context.Context, invocation.Invocation, InvocationContext) (transaction.Transaction[O, ipld.Builder], error)
+type ServiceMethod[O ipld.Builder, X failure.IPLDBuilderFailure] func(context.Context, invocation.Invocation, InvocationContext) (transaction.Transaction[O, X], error)
 
 // Service is a mapping of service names to handlers, used to define a
 // service implementation.
-type Service = map[ucan.Ability]ServiceMethod[ipld.Builder]
+type Service = map[ucan.Ability]ServiceMethod[ipld.Builder, failure.IPLDBuilderFailure]
 
 type ServiceInvocation = invocation.IssuedInvocation
 

--- a/server/server.go
+++ b/server/server.go
@@ -45,7 +45,11 @@ type InvocationContext interface {
 }
 
 // ServiceMethod is an invocation handler.
-type ServiceMethod[O ipld.Builder, X failure.IPLDBuilderFailure] func(context.Context, invocation.Invocation, InvocationContext) (transaction.Transaction[O, X], error)
+type ServiceMethod[O ipld.Builder, X failure.IPLDBuilderFailure] func(
+	context.Context,
+	invocation.Invocation,
+	InvocationContext,
+) (transaction.Transaction[O, X], error)
 
 // Service is a mapping of service names to handlers, used to define a
 // service implementation.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -177,13 +177,13 @@ func TestExecute(t *testing.T) {
 		rcpt := helpers.Must(reader.Read(rcptlnk, resp.Blocks()))
 
 		result.MatchResultR0(rcpt.Out(), func(ok uploadAddSuccess) {
-			fmt.Printf("%+v\n", ok)
+			t.Logf("%+v\n", ok)
 			require.Equal(t, ok.Root, rt)
 			require.Equal(t, ok.Status, "done")
 		}, func(x ipld.Node) {
 			f := asFailure(t, x)
-			fmt.Println(f.Message)
-			fmt.Println(*f.Stack)
+			t.Log(f.Message)
+			t.Log(*f.Stack)
 			require.Nil(t, f)
 		})
 	})
@@ -233,13 +233,13 @@ func TestExecute(t *testing.T) {
 		rcpt := helpers.Must(reader.Read(rcptlnk, resp.Blocks()))
 
 		result.MatchResultR0(rcpt.Out(), func(ok uploadAddSuccess) {
-			fmt.Printf("%+v\n", ok)
+			t.Logf("%+v\n", ok)
 			require.Equal(t, ok.Root, rt)
 			require.Equal(t, ok.Status, "done")
 		}, func(x ipld.Node) {
 			f := asFailure(t, x)
-			fmt.Println(f.Message)
-			fmt.Println(*f.Stack)
+			t.Log(f.Message)
+			t.Log(*f.Stack)
 			require.Nil(t, f)
 		})
 	})
@@ -267,7 +267,7 @@ func TestExecute(t *testing.T) {
 			t.Fatalf("expected error: %s", invs[0].Link())
 		}, func(x ipld.Node) {
 			f := asFailure(t, x)
-			fmt.Printf("%s %+v\n", *f.Name, f)
+			t.Logf("%s %+v\n", *f.Name, f)
 			require.Equal(t, *f.Name, "HandlerNotFoundError")
 		})
 	})
@@ -305,7 +305,7 @@ func TestExecute(t *testing.T) {
 			t.Fatalf("expected error: %s", invs[0].Link())
 		}, func(x ipld.Node) {
 			f := asFailure(t, x)
-			fmt.Printf("%s %+v\n", *f.Name, f)
+			t.Logf("%s %+v\n", *f.Name, f)
 			require.Equal(t, *f.Name, "HandlerExecutionError")
 		})
 	})
@@ -343,7 +343,7 @@ func TestExecute(t *testing.T) {
 			t.Fatalf("expected error: %s", invs[0].Link())
 		}, func(x ipld.Node) {
 			f := asFailure(t, x)
-			fmt.Printf("%s %+v\n", *f.Name, f)
+			t.Logf("%s %+v\n", *f.Name, f)
 			require.Equal(t, *f.Name, "UploadAddError")
 		})
 	})


### PR DESCRIPTION
This PR changes the server handler return types.

Previously a handler signature was:

```go
func[O any](Context, Capability[C], Invocation, InvocationContext) (O, fx.Effects, error)
```

It is now:

```go
func[O any, X failure.IPLDBuilderFailure](Context, Capability[C], Invocation, InvocationContext) (result.Result[O, X], fx.Effects, error)
```

i.e. Instead of returning a success value (`O`), it now returns a `result.Result[O, X]`.

This allows the handler to return a custom error in a `result.Result`. This is in the case where the error is _known_. Previously all errors would have a `name` of `HandlerExecutionError` and the actual error would be communicated in the `cause` property. This is awkward to unpack on the client, is redundant (every error is currently a `HandlerExecutionError`) and incompatible with the JS implementation.

The intention of `HandlerExecutionError` is a catch all for _unexpected errors_, however it is currently being used to communicate _all_ failures. This is my fault for rushing the implementation.

The failure type `X` is constrained to `failure.IPLDBuilderFailure`, which ensures known errors a) have a `name` property, b) are an `error` (and have a message) and c) have a `ToIPLD()` method.

To summarise, handlers should communicate _known_ errors as an error result, and unexpected errors in the `error` return value.

Note: there is an alternative to this https://github.com/storacha/go-ucanto/pull/56