### PR TITLE
feat: custom failures alternative

### DIFF
--- a/server/options.go
+++ b/server/options.go
@@ -61,8 +61,8 @@ func WithRevocationChecker(fn validator.RevocationCheckerFunc[any]) Option {
 	}
 }
 
-// WithErrorHandler configures a function to be called when errors occur during
-// execution of a handler.
+// WithErrorHandler configures a function to be called when errors that are not
+// a [failure.IPLDBuilderFailure] occur during execution of a handler.
 func WithErrorHandler(fn ErrorHandlerFunc) Option {
 	return func(cfg *srvConfig) error {
 		cfg.catch = fn

--- a/server/server.go
+++ b/server/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/storacha/go-ucanto/core/message"
 	"github.com/storacha/go-ucanto/core/receipt"
 	"github.com/storacha/go-ucanto/core/result"
+	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/did"
 	"github.com/storacha/go-ucanto/principal"
 	"github.com/storacha/go-ucanto/principal/ed25519/verifier"
@@ -60,6 +61,8 @@ type Server interface {
 	Context() InvocationContext
 	// Service is the actual service providing capability handlers.
 	Service() Service
+	// Catch allows an unexpected error that is not a [failure.IPLDBuilderFailure]
+	// to be logged.
 	Catch(err HandlerExecutionError[any])
 }
 
@@ -298,9 +301,12 @@ func Run(ctx context.Context, server Server, invocation ServiceInvocation) (rece
 		if errors.Is(err, context.Canceled) {
 			return nil, err
 		}
-		herr := NewHandlerExecutionError(err, cap)
-		server.Catch(herr)
-		return receipt.Issue(server.ID(), result.NewFailure(herr), ran.FromInvocation(invocation))
+		if _, ok := err.(failure.IPLDBuilderFailure); !ok {
+			herr := NewHandlerExecutionError(err, cap)
+			server.Catch(herr)
+			err = herr
+		}
+		return receipt.Issue(server.ID(), result.NewFailure(err), ran.FromInvocation(invocation))
 	}
 
 	fx := tx.Fx()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -74,6 +74,31 @@ func (ok uploadAddSuccess) ToIPLD() (ipld.Node, error) {
 	return nb.Build(), nil
 }
 
+type uploadAddFailure struct {
+	name    string
+	message string
+}
+
+func (x uploadAddFailure) Name() string {
+	return x.name
+}
+
+func (x uploadAddFailure) Error() string {
+	return x.message
+}
+
+func (x uploadAddFailure) ToIPLD() (ipld.Node, error) {
+	np := basicnode.Prototype.Any
+	nb := np.NewBuilder()
+	ma, _ := nb.BeginMap(2)
+	ma.AssembleKey().AssignString("name")
+	ma.AssembleValue().AssignString(x.name)
+	ma.AssembleKey().AssignString("message")
+	ma.AssembleValue().AssignString(x.message)
+	ma.Finish()
+	return nb.Build(), nil
+}
+
 var rcptsch = []byte(`
 	type Result union {
 		| UploadAddSuccess "ok"
@@ -282,6 +307,44 @@ func TestExecute(t *testing.T) {
 			f := asFailure(t, x)
 			fmt.Printf("%s %+v\n", *f.Name, f)
 			require.Equal(t, *f.Name, "HandlerExecutionError")
+		})
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		uploadadd := validator.NewCapability(
+			"upload/add",
+			schema.DIDString(),
+			schema.Struct[uploadAddCaveats](uploadAddCaveatsType(), nil),
+			nil,
+		)
+
+		server := helpers.Must(NewServer(
+			fixtures.Service,
+			WithServiceMethod(
+				uploadadd.Can(),
+				Provide(uploadadd, func(ctx context.Context, cap ucan.Capability[uploadAddCaveats], inv invocation.Invocation, ictx InvocationContext) (uploadAddSuccess, fx.Effects, error) {
+					return uploadAddSuccess{}, nil, uploadAddFailure{name: "UploadAddError", message: "boom"}
+				}),
+			),
+		))
+
+		conn := helpers.Must(client.NewConnection(fixtures.Service, server))
+		rt := cidlink.Link{Cid: cid.MustParse("bafkreiem4twkqzsq2aj4shbycd4yvoj2cx72vezicletlhi7dijjciqpui")}
+		cap := uploadadd.New(fixtures.Alice.DID().String(), uploadAddCaveats{Root: rt})
+		invs := []invocation.Invocation{helpers.Must(invocation.Invoke(fixtures.Alice, fixtures.Service, cap))}
+		resp := helpers.Must(client.Execute(t.Context(), invs, conn))
+		rcptlnk, ok := resp.Get(invs[0].Link())
+		require.True(t, ok, "missing receipt for invocation: %s", invs[0].Link())
+
+		reader := helpers.Must(receipt.NewReceiptReader[uploadAddSuccess, ipld.Node](rcptsch))
+		rcpt := helpers.Must(reader.Read(rcptlnk, resp.Blocks()))
+
+		result.MatchResultR0(rcpt.Out(), func(uploadAddSuccess) {
+			t.Fatalf("expected error: %s", invs[0].Link())
+		}, func(x ipld.Node) {
+			f := asFailure(t, x)
+			fmt.Printf("%s %+v\n", *f.Name, f)
+			require.Equal(t, *f.Name, "UploadAddError")
 		})
 	})
 


### PR DESCRIPTION
This is a non-breaking alternative to https://github.com/storacha/go-ucanto/pull/55 where the server inspects the error type to determine if it should wrap it with a `HandlerExecutionError`.

i.e. errors that are `failure.IPLDBuilderFailure` are not treated as unexpected.

This is perhaps less churn, but also less explicit.