### PR TITLE
feat: Add Generic Principal Decoding

### DIFF
--- a/principal/decode.go
+++ b/principal/decode.go
@@ -1,0 +1,133 @@
+package principal
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/multiformats/go-varint"
+	"github.com/storacha/go-ucanto/principal/ed25519/signer"
+	"github.com/storacha/go-ucanto/principal/ed25519/verifier"
+	rsasigner "github.com/storacha/go-ucanto/principal/rsa/signer"
+	rsaverifier "github.com/storacha/go-ucanto/principal/rsa/verifier"
+	"github.com/storacha/go-ucanto/ucan"
+)
+
+// DecodeSigner decodes a multiformat encoded signer back to the appropriate
+// implementation (ed25519 or RSA) based on the codec prefix.
+func DecodeSigner(encoded []byte) (Signer, error) {
+	code, err := varint.ReadUvarint(bytes.NewReader(encoded))
+	if err != nil {
+		return nil, fmt.Errorf("reading signer codec: %w", err)
+	}
+
+	switch code {
+	case signer.Code:
+		return signer.Decode(encoded)
+	case rsasigner.Code:
+		return rsasigner.Decode(encoded)
+	default:
+		return nil, fmt.Errorf("unsupported signer codec: %d", code)
+	}
+}
+
+// DecodeVerifier decodes a multiformat encoded verifier back to the appropriate
+// implementation (ed25519 or RSA) based on the codec prefix.
+func DecodeVerifier(encoded []byte) (ucan.Verifier, error) {
+	code, err := varint.ReadUvarint(bytes.NewReader(encoded))
+	if err != nil {
+		return nil, fmt.Errorf("reading verifier codec: %w", err)
+	}
+
+	switch code {
+	case verifier.Code:
+		return verifier.Decode(encoded)
+	case rsaverifier.Code:
+		return rsaverifier.Decode(encoded)
+	default:
+		return nil, fmt.Errorf("unsupported verifier codec: %d", code)
+	}
+}
+
+// DecodePrincipal attempts to decode as both signer and verifier, returning
+// whichever succeeds.
+func DecodePrincipal(encoded []byte) (interface{}, error) {
+	// Try as signer first
+	if s, err := DecodeSigner(encoded); err == nil {
+		return s, nil
+	}
+
+	// Try as verifier
+	if v, err := DecodeVerifier(encoded); err == nil {
+		return v, nil
+	}
+
+	return nil, fmt.Errorf("unable to decode as either signer or verifier")
+}
+
+// ComposedParser implements a parser that tries multiple principal parsers
+type ComposedParser struct {
+	parsers []Parser
+}
+
+// Parser interface for parsing DIDs into verifiers
+type Parser interface {
+	Parse(did string) (ucan.Verifier, error)
+}
+
+// NewComposedParser creates a new composed parser with the given parsers
+func NewComposedParser(parsers ...Parser) *ComposedParser {
+	return &ComposedParser{parsers: parsers}
+}
+
+// Parse attempts to parse the DID using each parser in sequence
+func (cp *ComposedParser) Parse(did string) (ucan.Verifier, error) {
+	if len(did) < 4 || did[:4] != "did:" {
+		return nil, fmt.Errorf("expected DID but got %s", did)
+	}
+
+	var lastErr error
+	for _, parser := range cp.parsers {
+		if v, err := parser.Parse(did); err == nil {
+			return v, nil
+		} else {
+			lastErr = err
+		}
+	}
+
+	if lastErr != nil {
+		return nil, fmt.Errorf("unsupported DID %s: %w", did, lastErr)
+	}
+	return nil, fmt.Errorf("unsupported DID %s", did)
+}
+
+// Or adds another parser to the composed parser
+func (cp *ComposedParser) Or(parser Parser) *ComposedParser {
+	return &ComposedParser{parsers: append(cp.parsers, parser)}
+}
+
+// Ed25519Parser implements Parser for Ed25519 DIDs
+type Ed25519Parser struct{}
+
+func (p Ed25519Parser) Parse(did string) (ucan.Verifier, error) {
+	return verifier.Parse(did)
+}
+
+// RSAParser implements Parser for RSA DIDs
+type RSAParser struct{}
+
+func (p RSAParser) Parse(did string) (ucan.Verifier, error) {
+	return rsaverifier.Parse(did)
+}
+
+// DefaultParser returns a composed parser with all supported principal types
+func DefaultParser() *ComposedParser {
+	return NewComposedParser(
+		Ed25519Parser{},
+		RSAParser{},
+	)
+}
+
+// ParseDID parses a DID string using the default composed parser
+func ParseDID(did string) (ucan.Verifier, error) {
+	return DefaultParser().Parse(did)
+}

--- a/principal/decode_test.go
+++ b/principal/decode_test.go
@@ -1,0 +1,139 @@
+package principal
+
+import (
+	"testing"
+
+	"github.com/storacha/go-ucanto/principal/ed25519/signer"
+	rsasigner "github.com/storacha/go-ucanto/principal/rsa/signer"
+	"github.com/storacha/go-ucanto/ucan"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeSigner(t *testing.T) {
+	t.Run("Ed25519 signer", func(t *testing.T) {
+		original, err := signer.Generate()
+		require.NoError(t, err)
+
+		encoded := original.Encode()
+		decoded, err := DecodeSigner(encoded)
+		require.NoError(t, err)
+
+		require.Equal(t, original.DID().String(), decoded.DID().String())
+	})
+
+	t.Run("RSA signer", func(t *testing.T) {
+		original, err := rsasigner.Generate()
+		require.NoError(t, err)
+
+		encoded := original.Encode()
+		decoded, err := DecodeSigner(encoded)
+		require.NoError(t, err)
+
+		require.Equal(t, original.DID().String(), decoded.DID().String())
+	})
+
+	t.Run("Invalid data", func(t *testing.T) {
+		_, err := DecodeSigner([]byte{0xFF, 0xFF})
+		require.Error(t, err)
+	})
+}
+
+func TestDecodeVerifier(t *testing.T) {
+	t.Run("Ed25519 verifier", func(t *testing.T) {
+		s, err := signer.Generate()
+		require.NoError(t, err)
+		original := s.Verifier()
+
+		encoded := original.Encode()
+		decoded, err := DecodeVerifier(encoded)
+		require.NoError(t, err)
+
+		require.Equal(t, original.DID().String(), decoded.DID().String())
+	})
+
+	t.Run("RSA verifier", func(t *testing.T) {
+		s, err := rsasigner.Generate()
+		require.NoError(t, err)
+		original := s.Verifier()
+
+		encoded := original.Encode()
+		decoded, err := DecodeVerifier(encoded)
+		require.NoError(t, err)
+
+		require.Equal(t, original.DID().String(), decoded.DID().String())
+	})
+}
+
+func TestDecodePrincipal(t *testing.T) {
+	t.Run("Decode signer", func(t *testing.T) {
+		s, err := signer.Generate()
+		require.NoError(t, err)
+
+		encoded := s.Encode()
+		decoded, err := DecodePrincipal(encoded)
+		require.NoError(t, err)
+
+		signer, ok := decoded.(Signer)
+		require.True(t, ok)
+		require.Equal(t, s.DID().String(), signer.DID().String())
+	})
+
+	t.Run("Decode verifier", func(t *testing.T) {
+		s, err := signer.Generate()
+		require.NoError(t, err)
+		v := s.Verifier()
+
+		encoded := v.Encode()
+		decoded, err := DecodePrincipal(encoded)
+		require.NoError(t, err)
+
+		verifier, ok := decoded.(ucan.Verifier)
+		require.True(t, ok)
+		require.Equal(t, v.DID().String(), verifier.DID().String())
+	})
+}
+
+func TestParseDID(t *testing.T) {
+	t.Run("Parse Ed25519 DID", func(t *testing.T) {
+		s, err := signer.Generate()
+		require.NoError(t, err)
+
+		verifier, err := ParseDID(s.DID().String())
+		require.NoError(t, err)
+		require.Equal(t, s.DID().String(), verifier.DID().String())
+	})
+
+	t.Run("Parse RSA DID", func(t *testing.T) {
+		s, err := rsasigner.Generate()
+		require.NoError(t, err)
+
+		verifier, err := ParseDID(s.DID().String())
+		require.NoError(t, err)
+		require.Equal(t, s.DID().String(), verifier.DID().String())
+	})
+
+	t.Run("Invalid DID", func(t *testing.T) {
+		_, err := ParseDID("not-a-did")
+		require.Error(t, err)
+	})
+}
+
+func TestComposedParser(t *testing.T) {
+	parser := NewComposedParser(Ed25519Parser{}, RSAParser{})
+
+	// Test with Ed25519
+	s1, err := signer.Generate()
+	require.NoError(t, err)
+
+	v1, err := parser.Parse(s1.DID().String())
+	require.NoError(t, err)
+	require.Equal(t, s1.DID().String(), v1.DID().String())
+
+	// Test with RSA
+	s2, err := rsasigner.Generate()
+	require.NoError(t, err)
+
+	v2, err := parser.Parse(s2.DID().String())
+	require.NoError(t, err)
+	require.Equal(t, s2.DID().String(), v2.DID().String())
+}


### PR DESCRIPTION
 generic decoding functions for principals (signers and verifiers) that can automatically detect and decode the correct implementation based on multiformat codec prefixes.
[issue](https://github.com/storacha/go-ucanto/issues/46)