### PR TITLE
fix: proactively close the response body

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -117,6 +117,7 @@ func Execute(ctx context.Context, invocations []invocation.Invocation, conn Conn
 	if err != nil {
 		return nil, fmt.Errorf("sending message: %w", err)
 	}
+	defer res.Body().Close()
 
 	output, err := conn.Codec().Decode(res)
 	if err != nil {


### PR DESCRIPTION
Small fix the the regular client to close the response body proactively after the request.