### PR TITLE
fix: encode and decode nil caveats

### DIFF
--- a/ucan/datamodel/payload/payload.ipldsch
+++ b/ucan/datamodel/payload/payload.ipldsch
@@ -18,7 +18,7 @@ type Capability struct {
   # Must be all lower-case `/` delimeted with at least one path segment.
   can String
   # Any additional domain specific details and/or restrictions of the capability
-  nb Any
+  nb optional Any
 }
 
 type Fact { String: Any }

--- a/ucan/lib_test.go
+++ b/ucan/lib_test.go
@@ -1,0 +1,57 @@
+package ucan_test
+
+import (
+	"testing"
+
+	"github.com/ipld/go-ipld-prime"
+	"github.com/storacha/go-ucanto/core/ipld/codec/cbor"
+	"github.com/storacha/go-ucanto/principal/ed25519/signer"
+	pdm "github.com/storacha/go-ucanto/ucan/datamodel/payload"
+	udm "github.com/storacha/go-ucanto/ucan/datamodel/ucan"
+	"github.com/storacha/go-ucanto/ucan/formatter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatamodel(t *testing.T) {
+	t.Run("nil caveats", func(t *testing.T) {
+		issuer, err := signer.Generate()
+		require.NoError(t, err)
+
+		audience, err := signer.Generate()
+		require.NoError(t, err)
+
+		caps := []udm.CapabilityModel{{
+			With: issuer.DID().String(),
+			Can:  "test/nilcaveats",
+		}}
+
+		payload := pdm.PayloadModel{
+			Iss: issuer.DID().String(),
+			Aud: audience.DID().String(),
+			Att: caps,
+			Prf: []string{},
+			Fct: []udm.FactModel{},
+		}
+
+		sigPayload, err := formatter.FormatSignPayload(payload, "0.9.1", issuer.SignatureAlgorithm())
+		require.NoError(t, err)
+
+		model := udm.UCANModel{
+			V:   "0.9.1",
+			S:   issuer.Sign([]byte(sigPayload)).Bytes(),
+			Iss: issuer.DID().Bytes(),
+			Aud: audience.DID().Bytes(),
+			Att: caps,
+			Prf: []ipld.Link{},
+			Fct: []udm.FactModel{},
+		}
+
+		bytes, err := cbor.Encode(&model, udm.Type())
+		require.NoError(t, err)
+
+		var decoded udm.UCANModel
+		err = cbor.Decode(bytes, &decoded, udm.Type())
+		require.NoError(t, err)
+		require.Equal(t, model.Att, decoded.Att)
+	})
+}


### PR DESCRIPTION
In https://github.com/storacha/go-ucanto/pull/52 we tried to allow nil caveats by making the `nb` field `optional` in the UCAN datamodel. However this was not a complete solution as it also needed to be allowed in the signature payload datamodel.

Fixes:

```
panic: interface conversion: interface is nil, not datamodel.Node

goroutine 918660 [running]:
github.com/ipld/go-ipld-prime/node/bindnode.(*_structIterator).Next(0xc003b31a40)
        /root/go/pkg/mod/github.com/ipld/go-ipld-prime@v0.21.1-0.20240917223228-6148356a4c2e/node/bindnode/node.go:1486 +0x745
github.com/ipld/go-ipld-prime/node/bindnode.(*_structIteratorRepr).Next(0xc003b31a40)
        /root/go/pkg/mod/github.com/ipld/go-ipld-prime@v0.21.1-0.20240917223228-6148356a4c2e/node/bindnode/repr.go:1258 +0x11f
github.com/ipld/go-ipld-prime/codec/dagjson.Marshal({0x29949e0, 0xc0023c2ea0}, {0x2960f80, 0xc0000fc6e0}, {0x70?, 0x2e?, 0x3c?})
        /root/go/pkg/mod/github.com/ipld/go-ipld-prime@v0.21.1-0.20240917223228-6148356a4c2e/codec/dagjson/marshal.go:77 +0xabe
github.com/ipld/go-ipld-prime/codec/dagjson.Marshal({0x29949e0, 0xc0023c2d80}, {0x2960f80, 0xc0000fc6e0}, {0x20?, 0xd6?, 0x10?})
        /root/go/pkg/mod/github.com/ipld/go-ipld-prime@v0.21.1-0.20240917223228-6148356a4c2e/codec/dagjson/marshal.go:160 +0xef1
github.com/ipld/go-ipld-prime/codec/dagjson.Marshal({0x29949e0, 0xc0023c2cc0}, {0x2960f80, 0xc0000fc6e0}, {0xc0?, 0x65?, 0x11?})
        /root/go/pkg/mod/github.com/ipld/go-ipld-prime@v0.21.1-0.20240917223228-6148356a4c2e/codec/dagjson/marshal.go:115 +0xe30
github.com/ipld/go-ipld-prime/codec/dagjson.EncodeOptions.Encode(...)
        /root/go/pkg/mod/github.com/ipld/go-ipld-prime@v0.21.1-0.20240917223228-6148356a4c2e/codec/dagjson/marshal.go:42
github.com/ipld/go-ipld-prime/codec/dagjson.Encode({0x29949e0, 0xc0023c2cc0}, {0x295bbe0, 0xc0023c2cf0})
        /root/go/pkg/mod/github.com/ipld/go-ipld-prime@v0.21.1-0.20240917223228-6148356a4c2e/codec/dagjson/multicodec.go:49 +0x125
github.com/ipld/go-ipld-prime.EncodeStreaming({0x295bbe0, 0xc0023c2cf0}, {0x29949e0?, 0xc0023c2cc0?}, 0x26b0c50)
        /root/go/pkg/mod/github.com/ipld/go-ipld-prime@v0.21.1-0.20240917223228-6148356a4c2e/codecHelpers.go:39 +0x85
github.com/ipld/go-ipld-prime.Encode({0x29949e0, 0xc0023c2cc0}, 0x26b0c50)
        /root/go/pkg/mod/github.com/ipld/go-ipld-prime@v0.21.1-0.20240917223228-6148356a4c2e/codecHelpers.go:30 +0x50
github.com/ipld/go-ipld-prime.Marshal(0x26b0c50, {0x1e6d760?, 0xc00062b380?}, {0x297f1c0?, 0xc00235a730?}, {0x0?, 0x2317d77?, 0x3?})
        /root/go/pkg/mod/github.com/ipld/go-ipld-prime@v0.21.1-0.20240917223228-6148356a4c2e/codecHelpers.go:113 +0x5c
github.com/storacha/go-ucanto/ucan/formatter.FormatPayload({{0xc000703f80, 0x38}, {0xc000703fc0, 0x38}, {0xc00080f5c0, 0x4, 0x4}, {0xc004666670, 0x1, 0x1}, ...})
        /root/go/pkg/mod/github.com/storacha/go-ucanto@v0.6.1/ucan/formatter/formatter.go:40 +0xbb
github.com/storacha/go-ucanto/ucan/formatter.FormatSignPayload({{0xc000703f80, 0x38}, {0xc000703fc0, 0x38}, {0xc00080f5c0, 0x4, 0x4}, {0xc004666670, 0x1, 0x1}, ...}, ...)
        /root/go/pkg/mod/github.com/storacha/go-ucanto@v0.6.1/ucan/formatter/formatter.go:19 +0x78
github.com/storacha/go-ucanto/ucan.encodeSignaturePayload(...)
        /root/go/pkg/mod/github.com/storacha/go-ucanto@v0.6.1/ucan/lib.go:188
github.com/storacha/go-ucanto/ucan.VerifySignature({0x298b720, 0xc002736280}, {0x7848f25df8e8, 0xc0025fc000})
        /root/go/pkg/mod/github.com/storacha/go-ucanto@v0.6.1/ucan/lib.go:215 +0x3a8
github.com/storacha/go-ucanto/validator.VerifySignature({0x2993e00, 0xc00250a140}, {0x297e300, 0xc0025fc000})
        /root/go/pkg/mod/github.com/storacha/go-ucanto@v0.6.1/validator/lib.go:351 +0x74
github.com/storacha/go-ucanto/validator.VerifyAuthorization({0x2978b20, 0xc003b31180}, {0x2993e00, 0xc00250a140}, {0xc004666660, 0x1, 0x1}, {0x7848f252ffc0, 0xc003f552c0})
        /root/go/pkg/mod/github.com/storacha/go-ucanto@v0.6.1/validator/lib.go:311 +0x1a5
github.com/storacha/go-ucanto/validator.Validate({0x2978b20, 0xc003b31180}, {0x2993e00, 0xc00250a140}, {0xc004666660, 0x1, 0x1}, {0x7848f252ffc0, 0xc003f552c0})
        /root/go/pkg/mod/github.com/storacha/go-ucanto@v0.6.1/validator/lib.go:293 +0x1de
github.com/storacha/go-ucanto/validator.ResolveSources({0x2978b20, 0xc003b31180}, {0x2969938?, 0xc0045f8240?}, {0x7848f252ffc0, 0xc003f552c0})
        /root/go/pkg/mod/github.com/storacha/go-ucanto@v0.6.1/validator/lib.go:503 +0x9a5
github.com/storacha/go-ucanto/validator.ResolveMatch[...].func1()
        /root/go/pkg/mod/github.com/storacha/go-ucanto@v0.6.1/validator/lib.go:457 +0x89
created by github.com/storacha/go-ucanto/validator.ResolveMatch[...] in goroutine 918658
        /root/go/pkg/mod/github.com/storacha/go-ucanto@v0.6.1/validator/lib.go:456 +0x310
```