### PR TITLE
fix: nobody panic

### DIFF
--- a/core/ipld/codec/cbor/cbor.go
+++ b/core/ipld/codec/cbor/cbor.go
@@ -2,6 +2,7 @@ package cbor
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/dagcbor"
@@ -35,7 +36,7 @@ func Encode(val any, typ schema.Type, opts ...bindnode.Option) (bytes []byte, er
 			} else if asErr, ok := r.(error); ok {
 				err = asErr
 			} else {
-				err = errors.New("unknown panic encoding CBOR")
+				err = fmt.Errorf("unknown panic encoding CBOR: %+v", r)
 			}
 		}
 	}()

--- a/core/ipld/codec/json/json.go
+++ b/core/ipld/codec/json/json.go
@@ -2,6 +2,7 @@ package json
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/dagjson"
@@ -35,7 +36,7 @@ func Encode(val any, typ schema.Type, opts ...bindnode.Option) (bytes []byte, er
 			} else if asErr, ok := r.(error); ok {
 				err = asErr
 			} else {
-				err = errors.New("unknown panic encoding JSON")
+				err = fmt.Errorf("unknown panic encoding JSON: %+v", r)
 			}
 		}
 	}()


### PR DESCRIPTION
In https://github.com/storacha/go-ucanto/pull/69 it was discovered that IPLD codec `Marshal` functions can panic. Make that not a thing.