### PR TITLE
fix: pass context to receipt logging function

### DIFF
--- a/server/retrieval/server.go
+++ b/server/retrieval/server.go
@@ -191,8 +191,8 @@ func (srv *Server) Catch(err server.HandlerExecutionError[any]) {
 	srv.server.Catch(err)
 }
 
-func (srv *Server) LogReceipt(rcpt receipt.AnyReceipt, inv invocation.Invocation) {
-	srv.server.LogReceipt(rcpt, inv)
+func (srv *Server) LogReceipt(ctx context.Context, rcpt receipt.AnyReceipt, inv invocation.Invocation) {
+	srv.server.LogReceipt(ctx, rcpt, inv)
 }
 
 var _ CachingServer = (*Server)(nil)
@@ -469,7 +469,7 @@ func Run(ctx context.Context, srv server.Server[Service], invocation server.Serv
 		return nil, Response{}, err
 	}
 
-	srv.LogReceipt(rcpt, invocation)
+	srv.LogReceipt(ctx, rcpt, invocation)
 
 	return rcpt, resp, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -67,7 +67,7 @@ type Server[S any] interface {
 	// Service is the actual service providing capability handlers.
 	Service() S
 	Catch(err HandlerExecutionError[any])
-	LogReceipt(rcpt receipt.AnyReceipt, inv invocation.Invocation)
+	LogReceipt(ctx context.Context, rcpt receipt.AnyReceipt, inv invocation.Invocation)
 }
 
 // Server is a materialized service that is configured to use a specific
@@ -86,7 +86,7 @@ type ErrorHandlerFunc func(err HandlerExecutionError[any])
 
 // ReceiptLoggerFunc allows receipts generated during handler execution to be logged.
 // The original invocation is also provided for reference.
-type ReceiptLoggerFunc func(receipt.AnyReceipt, invocation.Invocation)
+type ReceiptLoggerFunc func(ctx context.Context, rcpt receipt.AnyReceipt, inv invocation.Invocation)
 
 func NewServer(id principal.Signer, options ...Option) (ServerView[Service], error) {
 	cfg := srvConfig{service: Service{}}
@@ -225,9 +225,9 @@ func (srv *server) Catch(err HandlerExecutionError[any]) {
 	srv.catch(err)
 }
 
-func (srv *server) LogReceipt(rcpt receipt.AnyReceipt, inv invocation.Invocation) {
+func (srv *server) LogReceipt(ctx context.Context, rcpt receipt.AnyReceipt, inv invocation.Invocation) {
 	if srv.logReceipt != nil {
-		srv.logReceipt(rcpt, inv)
+		srv.logReceipt(ctx, rcpt, inv)
 	}
 }
 
@@ -334,7 +334,7 @@ func Run(ctx context.Context, server Server[Service], invocation ServiceInvocati
 		return receipt.Issue(server.ID(), result.NewFailure(herr), ran.FromInvocation(invocation))
 	}
 
-	server.LogReceipt(rcpt, invocation)
+	server.LogReceipt(ctx, rcpt, invocation)
 
 	return rcpt, nil
 }


### PR DESCRIPTION
pass the request context object to the receipt logging function so that it can be propagated to things it calls