### PR TITLE
feat: ReceiptLogger can return errors

### DIFF
--- a/server/retrieval/server.go
+++ b/server/retrieval/server.go
@@ -191,8 +191,8 @@ func (srv *Server) Catch(err server.HandlerExecutionError[any]) {
 	srv.server.Catch(err)
 }
 
-func (srv *Server) LogReceipt(ctx context.Context, rcpt receipt.AnyReceipt, inv invocation.Invocation) {
-	srv.server.LogReceipt(ctx, rcpt, inv)
+func (srv *Server) LogReceipt(ctx context.Context, rcpt receipt.AnyReceipt, inv invocation.Invocation) error {
+	return srv.server.LogReceipt(ctx, rcpt, inv)
 }
 
 var _ CachingServer = (*Server)(nil)
@@ -469,7 +469,9 @@ func Run(ctx context.Context, srv server.Server[Service], invocation server.Serv
 		return nil, Response{}, err
 	}
 
-	srv.LogReceipt(ctx, rcpt, invocation)
+	if err := srv.LogReceipt(ctx, rcpt, invocation); err != nil {
+		return nil, Response{}, err
+	}
 
 	return rcpt, resp, nil
 }


### PR DESCRIPTION
Ref: https://github.com/storacha/piri/issues/174

Allow `ReceiptLogger` to return errors. The request will fail if an error is returned.