### PR TITLE
feat: allow public retrievals

### DIFF
--- a/transport/headercar/message/header.go
+++ b/transport/headercar/message/header.go
@@ -21,7 +21,10 @@ const (
 	MaxHeaderSizeBytes = 4 * 1024
 )
 
-var ErrHeaderTooLarge = errors.New("maximum agent message header size exceeded")
+var (
+	ErrHeaderTooLarge = errors.New("maximum agent message header size exceeded")
+	ErrMissingHeader  = fmt.Errorf("missing %s header", HeaderName)
+)
 
 type encodeConfig struct {
 	maxSize int

--- a/transport/headercar/response/response.go
+++ b/transport/headercar/response/response.go
@@ -23,7 +23,7 @@ func Encode(msg message.AgentMessage) (transport.HTTPResponse, error) {
 func Decode(response transport.HTTPResponse) (message.AgentMessage, error) {
 	msgHdr := response.Headers().Get(hcmsg.HeaderName)
 	if msgHdr == "" {
-		return nil, fmt.Errorf("missing %s header in response", hcmsg.HeaderName)
+		return nil, hcmsg.ErrMissingHeader
 	}
 	return hcmsg.DecodeHeader(msgHdr)
 }


### PR DESCRIPTION
This PR enables the UCAN authorized retrieval client to allow retrievals from public buckets. That is, public URLs that when requested return the data but NOT an `X-Agent-Message` header.