### PR TITLE
fix: proof pruner handles ucan.NoCaveats capabilities

### DIFF
--- a/validator/proof_pruning.go
+++ b/validator/proof_pruning.go
@@ -24,6 +24,8 @@ import (
 // network).
 func NewProofPruner[Caveats any](attestor principal.Verifier, cap CapabilityParser[Caveats]) delegation.ProofPruner {
 	return func(issuer ucan.Signer, audience ucan.Principal, capabilities []ucan.Capability[ucan.CaveatBuilder], options ...delegation.Option) (delegation.Proofs, error) {
+		capabilities = replaceNoCaveatsCaps(capabilities, cap)
+
 		draft, err := delegation.Delegate(issuer, audience, capabilities, options...)
 		if err != nil {
 			return nil, fmt.Errorf("building draft delegation: %w", err)
@@ -53,6 +55,30 @@ func NewProofPruner[Caveats any](attestor principal.Verifier, cap CapabilityPars
 
 		return prunedPfs, nil
 	}
+}
+
+// replaceNoCaveatsCaps returns a copy of capabilities where any capability
+// whose ability matches cap and whose Nb is ucan.NoCaveats is replaced with a
+// new capability carrying the zero value of Caveats. NoCaveats encodes as a
+// schema-less empty map in IPLD; the capability parser's Nb schema reader
+// cannot rebind that to the specific Caveats type. Using the zero value of
+// Caveats produces a properly typed IPLD representation that the parser can
+// handle.
+func replaceNoCaveatsCaps[Caveats any](capabilities []ucan.Capability[ucan.CaveatBuilder], cap CapabilityParser[Caveats]) []ucan.Capability[ucan.CaveatBuilder] {
+	result := make([]ucan.Capability[ucan.CaveatBuilder], len(capabilities))
+	copy(result, capabilities)
+	for i, c := range capabilities {
+		if _, ok := c.Nb().(ucan.NoCaveats); !ok || c.Can() != cap.Can() {
+			continue
+		}
+		zeroCaveats := *new(Caveats)
+		if bc, ok := any(zeroCaveats).(ucan.CaveatBuilder); ok {
+			result[i] = ucan.NewCapability(c.Can(), c.With(), bc)
+		} else if bc, ok := any(&zeroCaveats).(ucan.CaveatBuilder); ok {
+			result[i] = ucan.NewCapability(c.Can(), c.With(), bc)
+		}
+	}
+	return result
 }
 
 // PruneProofs selects the minimal subset of proofs from dlg's embedded proof

--- a/validator/proof_pruning_test.go
+++ b/validator/proof_pruning_test.go
@@ -1,0 +1,80 @@
+package validator
+
+import (
+	"testing"
+
+	goipld "github.com/ipld/go-ipld-prime"
+	"github.com/storacha/go-ucanto/core/delegation"
+	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/schema"
+	"github.com/storacha/go-ucanto/testing/fixtures"
+	"github.com/storacha/go-ucanto/testing/helpers"
+	"github.com/storacha/go-ucanto/ucan"
+	"github.com/stretchr/testify/require"
+)
+
+// testFetchCaveats is used by the test/fetch capability. The URL field is
+// required (not optional) and has a meaningful zero value (""), which
+// demonstrates that NoCaveats replacement works for non-optional fields too.
+type testFetchCaveats struct {
+	Url string
+}
+
+func (tfc testFetchCaveats) ToIPLD() (ipld.Node, error) {
+	return ipld.WrapWithRecovery(&tfc, testFetchTyp.TypeByName("TestFetchCaveats"))
+}
+
+var testFetchTyp = helpers.Must(goipld.LoadSchemaBytes([]byte(`
+	type TestFetchCaveats struct {
+		url String
+	}
+`)))
+
+var testFetch = NewCapability(
+	"test/fetch",
+	schema.DIDString(),
+	schema.Struct[testFetchCaveats](testFetchTyp.TypeByName("TestFetchCaveats"), nil),
+	DefaultDerives[testFetchCaveats],
+)
+
+// TestNewProofPrunerNoCaveats verifies that NewProofPruner handles capabilities
+// whose Nb is ucan.NoCaveats. NoCaveats encodes as a schema-less empty map {}
+// in IPLD, which the capability parser's Nb schema reader cannot rebind to the
+// specific Caveats type. The pruner must replace NoCaveats with the zero value
+// of Caveats before building the draft delegation used for proof chain
+// validation.
+func TestNewProofPrunerNoCaveats(t *testing.T) {
+	// Service delegates test/fetch to Alice with NoCaveats – the common
+	// pattern callers use when they have no specific caveats to attach.
+	proof, err := delegation.Delegate(
+		fixtures.Service,
+		fixtures.Alice,
+		[]ucan.Capability[ucan.NoCaveats]{
+			ucan.NewCapability(testFetch.Can(), fixtures.Service.DID().String(), ucan.NoCaveats{}),
+		},
+		delegation.WithNoExpiration(),
+	)
+	require.NoError(t, err)
+
+	pruner := NewProofPruner(fixtures.Service.Verifier(), testFetch)
+
+	// Alice re-delegates to Bob with NoCaveats and proof pruning enabled.
+	// Before the fix the pruner would error: it built a draft delegation with
+	// NoCaveats, which encodes as {} in IPLD. When the validation logic then
+	// tried to parse that capability it called the TestFetchCaveats schema
+	// reader on {}, which failed because "url" is a required field.
+	dlg, err := delegation.Delegate(
+		fixtures.Alice,
+		fixtures.Bob,
+		[]ucan.Capability[ucan.NoCaveats]{
+			ucan.NewCapability(testFetch.Can(), fixtures.Service.DID().String(), ucan.NoCaveats{}),
+		},
+		delegation.WithNoExpiration(),
+		delegation.WithProof(delegation.FromDelegation(proof)),
+		delegation.WithProofPruning(pruner),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, dlg)
+	// The pruner should retain exactly the one proof that authorises Alice.
+	require.Len(t, dlg.Proofs(), 1)
+}


### PR DESCRIPTION
Ref. https://github.com/storacha/guppy/issues/378

Replace `NoCaveats` with the zero-value of whatever caveats type the capability being pruned for has. This allows callers to keep issuing delegations with `NoCaveats` while avoiding the capability parser failing when it attempts to parse an empty IPLD object.